### PR TITLE
Update Adobe Middleware

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -143,19 +143,6 @@ describe(@"buildIntegrationObject Function", ^{
         configuration.trackApplicationLifecycleEvents = YES;
         [SEGAnalytics setupWithConfiguration:configuration];
         instance = [[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region];
-        [[SEGAnalytics sharedAnalytics] track:@"Product Rated"
-                                   properties:nil
-                                      options:@{ @"integrations": @{ @"All": @YES, @"Mixpanel": @NO }}];
-    });
-    
-    it(@"properly updates an empty integrations object with the marketingCloudId", ^{
-        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
-        NSDictionary *exisintgIntegrations = [NSDictionary new];
-        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
-        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
-        NSString *marketingCloudId = integrations[@"Adobe Analytics"][@"marketingCloudVisitorId"];
-        expect(marketingCloudId).to.equal(instance.cachedMarketingCloudId);
     });
     
     it(@"updates an empty integrations object with one k/v pair", ^{

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -143,6 +143,9 @@ describe(@"buildIntegrationObject Function", ^{
         configuration.trackApplicationLifecycleEvents = YES;
         [SEGAnalytics setupWithConfiguration:configuration];
         instance = [[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region];
+        [[SEGAnalytics sharedAnalytics] track:@"Product Rated"
+                                   properties:nil
+                                      options:@{ @"integrations": @{ @"All": @YES, @"Mixpanel": @NO }}];
     });
     
     it(@"properly updates an integrations object with other integration specific options with the marketingCloudId", ^{
@@ -152,7 +155,7 @@ describe(@"buildIntegrationObject Function", ^{
         SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
         NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
         NSString *marketingCloudId = integrations[@"Adobe Analytics"][@"marketingCloudVisitorId"];
-        expect(marketingCloudId).to.equal(instance.cachedMarketingCloudId);
+        expect(marketingCloudId).willNot.beNil();
     });
     
     it(@"properly updates an integrations object with other integration specific options with the marketingCloudId", ^{

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -143,9 +143,6 @@ describe(@"buildIntegrationObject Function", ^{
         configuration.trackApplicationLifecycleEvents = YES;
         [SEGAnalytics setupWithConfiguration:configuration];
         instance = [[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region];
-        [[SEGAnalytics sharedAnalytics] track:@"Product Rated"
-                                   properties:nil
-                                      options:@{ @"integrations": @{ @"All": @YES, @"Mixpanel": @NO }}];
     });
     
     it(@"will not set marketingCloudVisitorId on clean install and not block events", ^{
@@ -154,8 +151,8 @@ describe(@"buildIntegrationObject Function", ^{
         NSDictionary *exisintgIntegrations = [NSDictionary new];
         SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
         NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
-        NSString *marketingCloudId = integrations[@"Adobe Analytics"][@"marketingCloudVisitorId"];
-        expect(marketingCloudId).to.beNil();
+        NSInteger count = [integrations count];
+        expect(count).to.equal(0);
     });
     
     it(@"properly updates an empty integrations object with the marketingCloudId", ^{

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -6,42 +6,203 @@
 //  Copyright (c) 2019 Brie. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+#import <Specta/Specta.h>
+#import "Expecta.h"
+#import "SEGMCVIDTracker.h"
+#import <Analytics/SEGAnalytics.h>
+#import "SEGAppDelegate.h"
+#import "SEGPayload.h"
+
 // https://github.com/Specta/Specta
+@interface SEGMCVIDTracker (Testing)
 
-SpecBegin(InitialSpecs)
+- (NSURL * _Nonnull)createURL:callType integrationCode:(NSString * _Nonnull)integrationCode;
+- (NSMutableDictionary * _Nonnull)buildIntegrationsObject:(SEGPayload *_Nonnull)payload;
+@property(nonatomic, nonnull) NSString *cachedMarketingCloudId;
+@property(nonatomic, nonnull) NSString *cachedAdvertisingId;
+@property(nonatomic) NSUInteger currentRetryCount;
 
-// describe(@"these will fail", ^{
-//
-//     it(@"can do maths", ^{
-//         expect(1).to.equal(2);
-//     });
-//
-//     it(@"can read", ^{
-//         expect(@"number").to.equal(@"string");
-//     });
-//
-//     it(@"will wait for 10 seconds and fail", ^{
-//         waitUntil(^(DoneCallback done) {
-//
-//         });
-//     });
-// });
 
-describe(@"these will pass", ^{
+@end
 
-    it(@"can do maths", ^{
-        expect(1).beLessThan(23);
+SpecBegin(SEGMCVIDTracker)
+
+describe(@"SEGMCVID", ^{
+    __block NSString *organizationId;
+    __block NSString *region;
+    __block SEGAnalyticsConfiguration *configuration;
+    __block SEGMCVIDTracker *instance;
+    
+    beforeEach(^{
+        configuration =  [SEGAnalyticsConfiguration configurationWithWriteKey:@"some_write_key"];
+        organizationId = @"B3CB46FC57C6C8F77F000101@AdobeOrg";
+        region = @"6";
+        configuration.middlewares = @[[[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region]];
+        configuration.trackApplicationLifecycleEvents = YES;
+        [SEGAnalytics setupWithConfiguration:configuration];
+        instance = [[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region];
+        
+    });
+    
+    it(@"should properly update the cachedMarketingCloudID", ^{
+        NSString *cachedMarketingCloudId = instance.cachedMarketingCloudId;
+        expect(cachedMarketingCloudId).to.equal(@"28682618302214414870104420606205106680");
+    });
+    
+    it(@"should properly update the cachedAdvertisingId", ^{
+        NSString *cachedAdvertisingId = instance.cachedAdvertisingId;
+        expect(cachedAdvertisingId).to.equal(@"34629D8C-7B4F-4947-8E22-F1CC625889E5");
+    });
+    
+    it(@"should properly store the cachedMarketingCloudId in NSUserDefaults", ^{
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        NSString *storedMarketingCloudId = [defaults stringForKey:@"com.segment.mcvid.marketingCloudId"];
+        expect(storedMarketingCloudId).to.equal(@"28682618302214414870104420606205106680");
+    });
+    
+    it(@"should properly store the cachedAdvertisingId in NSUserDefaults", ^{
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        NSString *storedAdvertisingId = [defaults stringForKey:@"com.segment.mcvid.advertisingId"];
+        expect(storedAdvertisingId).to.equal(@"34629D8C-7B4F-4947-8E22-F1CC625889E5");
+    });
+    
+    it(@"can make basic identify calls", ^{
+        [[SEGAnalytics sharedAnalytics] identify:@"user12345"
+                                          traits:@{ @"email": @"test@test.com" }];
+    });
+    
+    it(@"can make basic track calls", ^{
+        [[SEGAnalytics sharedAnalytics] track:@"Item Purchased"
+                                   properties:@{ @"item": @"Sword of Heracles", @"revenue": @2.95 }];
+    });
+    
+    it(@"can make track calls with integration options", ^{
+        [[SEGAnalytics sharedAnalytics] track:@"Product Rated"
+                                   properties:nil
+                                      options:@{ @"integrations": @{ @"All": @YES, @"Mixpanel": @NO }}];
+    });
+    
+    it(@"can properly append marketingCloudId to track calls pre-existing AA integration options", ^{
+        [[SEGAnalytics sharedAnalytics] track:@"Product Removed"
+                                   properties:nil
+                                      options:@{ @"integrations": @{ @"All": @YES, @"Mixpanel": @NO, @"Adobe Analytics":@{ @"prop1":@"Hello World"} }}];
+    });
+    
+});
+
+describe(@"createURL function", ^{
+    __block NSString *organizationId;
+    __block NSString *region;
+    __block SEGAnalyticsConfiguration *configuration;
+    __block SEGMCVIDTracker *instance;
+    
+    beforeEach(^{
+        configuration =  [SEGAnalyticsConfiguration configurationWithWriteKey:@"some_write_key"];
+        organizationId = @"B3CB46FC57C6C8F77F000101@AdobeOrg";
+        region = @"6";
+        configuration.middlewares = @[[[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region]];
+        configuration.trackApplicationLifecycleEvents = YES;
+        [SEGAnalytics setupWithConfiguration:configuration];
+        instance = [[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region];
+        
     });
 
-    it(@"can read", ^{
-        expect(@"team").toNot.contain(@"I");
+    it(@"can properly create the synIntegrationCode url", ^{
+        NSString const *syncIntegrationCallType = @"syncIntegrationCode";
+        NSURL *url = [instance createURL:syncIntegrationCallType integrationCode:@"DSID_20915"];
+        NSString *urlString = url.absoluteString;
+        
+        NSString *expected = @"https://dpm.demdex.net/id?d_ver=2&d_rtbd=json&dcs_region=6&d_orgid=B3CB46FC57C6C8F77F000101@AdobeOrg&d_mid=28682618302214414870104420606205106680&d_cid_ic=DSID_20915%0134629D8C-7B4F-4947-8E22-F1CC625889E5";
+        expect(urlString).to.equal(expected);
     });
 
-    it(@"will wait and succeed", ^{
-        waitUntil(^(DoneCallback done) {
-            done();
-        });
+    it(@"can properly create the getMarketingCloudId url", ^{
+        NSString const *getCloudIdCallType = @"getMarketingCloudID";
+        NSURL *url = [instance createURL:getCloudIdCallType integrationCode:@"DSID_20915"];
+        NSString *urlString = url.absoluteString;
+        
+        NSString *expected = @"https://dpm.demdex.net/id?d_ver=2&d_rtbd=json&dcs_region=6&d_orgid=B3CB46FC57C6C8F77F000101@AdobeOrg";
+        expect(urlString).to.equal(expected);
     });
 });
 
+describe(@"buildIntegrationObject Function", ^{
+    __block NSString *organizationId;
+    __block NSString *region;
+    __block SEGAnalyticsConfiguration *configuration;
+    __block SEGMCVIDTracker *instance;
+
+    
+    beforeEach(^{
+        configuration =  [SEGAnalyticsConfiguration configurationWithWriteKey:@"some_write_key"];
+        organizationId = @"B3CB46FC57C6C8F77F000101@AdobeOrg";
+        region = @"6";
+        configuration.middlewares = @[[[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region]];
+        configuration.trackApplicationLifecycleEvents = YES;
+        [SEGAnalytics setupWithConfiguration:configuration];
+        instance = [[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region];
+    });
+    
+    it(@"properly updates an empty integrations object with the marketingCloudId", ^{
+        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
+        NSDictionary *exisintgIntegrations = [NSDictionary new];
+        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
+        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
+        NSString *marketingCloudId = integrations[@"Adobe Analytics"][@"marketingCloudVisitorId"];
+        expect(marketingCloudId).to.equal(instance.cachedMarketingCloudId);
+    });
+    
+    it(@"updates an empty integrations object with one k/v pair", ^{
+        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
+        NSDictionary *exisintgIntegrations = [NSDictionary new];
+        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
+        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
+        NSInteger count = [integrations count];
+        expect(count).to.equal(1);
+    });
+    
+    it(@"properly updates an integrations object with other integration specific options with the marketingCloudId", ^{
+        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
+        NSDictionary *exisintgIntegrations = [[NSDictionary alloc] initWithObjectsAndKeys: @NO, @"Mixpanel", nil];
+        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
+        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
+        NSString *marketingCloudId = integrations[@"Adobe Analytics"][@"marketingCloudVisitorId"];
+        expect(marketingCloudId).to.equal(instance.cachedMarketingCloudId);
+    });
+    
+    it(@"properly updates an integrations object with other integration specific options with the marketingCloudId", ^{
+        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
+        NSDictionary *exisintgIntegrations = [[NSDictionary alloc] initWithObjectsAndKeys: @NO, @"Mixpanel", nil];
+        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
+        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
+        NSInteger count = [integrations count];
+        expect(count).to.equal(2);
+    });
+    
+    it(@"properly updates the AA integrations object with the marketingCloudId without overriding existing options", ^{
+        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
+        NSDictionary *exisintgIntegrations = [[NSDictionary alloc] initWithObjectsAndKeys: @NO, @"Mixpanel", @{ @"prop1": @"hello world"}, @"Adobe Analytics", nil];
+        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
+        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
+        NSString *marketingCloudId = integrations[@"Adobe Analytics"][@"marketingCloudVisitorId"];
+        expect(marketingCloudId).to.equal(instance.cachedMarketingCloudId);
+    });
+    
+    it(@"properly updates the AA integrations object with the marketingCloudId without overriding existing options", ^{
+        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
+        NSDictionary *exisintgIntegrations = [[NSDictionary alloc] initWithObjectsAndKeys: @NO, @"Mixpanel", @{ @"prop1": @"hello world"}, @"Adobe Analytics", nil];
+        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
+        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
+        NSInteger count = [integrations count];
+        expect(count).to.equal(2);
+    });
+
+});
 SpecEnd

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -145,16 +145,6 @@ describe(@"buildIntegrationObject Function", ^{
         instance = [[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region];
     });
     
-    it(@"updates an empty integrations object with one k/v pair", ^{
-        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
-        NSDictionary *exisintgIntegrations = [NSDictionary new];
-        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
-        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
-        NSInteger count = [integrations count];
-        expect(count).to.equal(1);
-    });
-    
     it(@"properly updates an integrations object with other integration specific options with the marketingCloudId", ^{
         NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
                                  @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -45,20 +45,9 @@ describe(@"SEGMCVID", ^{
         
     });
     
-    it(@"should have nil cachedMarketingCloudID on clean install", ^{
-        NSString *cachedMarketingCloudId = instance.cachedMarketingCloudId;
-        expect(cachedMarketingCloudId).to.beNil();
-    });
-    
     it(@"should properly update the cachedAdvertisingId", ^{
         NSString *cachedAdvertisingId = instance.cachedAdvertisingId;
         expect(cachedAdvertisingId).willNot.beNil();
-    });
-    
-    it(@"should have nil value for cachedMarketingCloudId in NSUserDefaults on clean install", ^{
-        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        NSString *storedMarketingCloudId = [defaults stringForKey:@"com.segment.mcvid.marketingCloudId"];
-        expect(storedMarketingCloudId).to.beNil();
     });
     
     it(@"should properly store the cachedAdvertisingId in NSUserDefaults", ^{
@@ -126,94 +115,5 @@ describe(@"createURL function", ^{
         NSString *expected = @"https://dpm.demdex.net/id?d_ver=2&d_rtbd=json&dcs_region=6&d_orgid=B3CB46FC57C6C8F77F000101@AdobeOrg";
         expect(urlString).to.equal(expected);
     });
-});
-
-describe(@"buildIntegrationObject Function", ^{
-    __block NSString *organizationId;
-    __block NSString *region;
-    __block SEGAnalyticsConfiguration *configuration;
-    __block SEGMCVIDTracker *instance;
-
-    
-    beforeEach(^{
-        configuration =  [SEGAnalyticsConfiguration configurationWithWriteKey:@"some_write_key"];
-        organizationId = @"B3CB46FC57C6C8F77F000101@AdobeOrg";
-        region = @"6";
-        configuration.middlewares = @[[[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region]];
-        configuration.trackApplicationLifecycleEvents = YES;
-        [SEGAnalytics setupWithConfiguration:configuration];
-        instance = [[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region];
-    });
-    
-    it(@"will not set marketingCloudVisitorId on clean install and not block events", ^{
-        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
-        NSDictionary *exisintgIntegrations = [NSDictionary new];
-        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
-        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
-        NSInteger count = [integrations count];
-        expect(count).to.equal(0);
-    });
-    
-    it(@"properly updates an empty integrations object with the marketingCloudId", ^{
-        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
-        NSDictionary *exisintgIntegrations = [NSDictionary new];
-        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
-        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
-        NSString *marketingCloudId = integrations[@"Adobe Analytics"][@"marketingCloudVisitorId"];
-        expect(marketingCloudId).to.equal(instance.cachedMarketingCloudId);
-    });
-    
-    it(@"updates an empty integrations object with one k/v pair", ^{
-        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
-        NSDictionary *exisintgIntegrations = [NSDictionary new];
-        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
-        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
-        NSInteger count = [integrations count];
-        expect(count).to.equal(1);
-    });
-    
-    it(@"properly updates an integrations object with other integration specific options with the marketingCloudId", ^{
-        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
-        NSDictionary *exisintgIntegrations = [[NSDictionary alloc] initWithObjectsAndKeys: @NO, @"Mixpanel", nil];
-        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
-        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
-        NSString *marketingCloudId = integrations[@"Adobe Analytics"][@"marketingCloudVisitorId"];
-        expect(marketingCloudId).to.equal(instance.cachedMarketingCloudId);
-    });
-    
-    it(@"properly updates an integrations object with other integration specific options with the marketingCloudId", ^{
-        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
-        NSDictionary *exisintgIntegrations = [[NSDictionary alloc] initWithObjectsAndKeys: @NO, @"Mixpanel", nil];
-        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
-        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
-        NSInteger count = [integrations count];
-        expect(count).to.equal(2);
-    });
-    
-    it(@"properly updates the AA integrations object with the marketingCloudId without overriding existing options", ^{
-        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
-        NSDictionary *exisintgIntegrations = [[NSDictionary alloc] initWithObjectsAndKeys: @NO, @"Mixpanel", @{ @"prop1": @"hello world"}, @"Adobe Analytics", nil];
-        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
-        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
-        NSString *marketingCloudId = integrations[@"Adobe Analytics"][@"marketingCloudVisitorId"];
-        expect(marketingCloudId).to.equal(instance.cachedMarketingCloudId);
-    });
-    
-    it(@"properly updates the AA integrations object with the marketingCloudId without overriding existing options", ^{
-        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
-        NSDictionary *exisintgIntegrations = [[NSDictionary alloc] initWithObjectsAndKeys: @NO, @"Mixpanel", @{ @"prop1": @"hello world"}, @"Adobe Analytics", nil];
-        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
-        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
-        NSInteger count = [integrations count];
-        expect(count).to.equal(2);
-    });
-
 });
 SpecEnd

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -45,26 +45,26 @@ describe(@"SEGMCVID", ^{
         
     });
     
-    it(@"should properly update the cachedMarketingCloudID", ^{
+    it(@"should have nil cachedMarketingCloudID on clean install", ^{
         NSString *cachedMarketingCloudId = instance.cachedMarketingCloudId;
-        expect(cachedMarketingCloudId).to.equal(@"28682618302214414870104420606205106680");
+        expect(cachedMarketingCloudId).to.beNil();
     });
     
     it(@"should properly update the cachedAdvertisingId", ^{
         NSString *cachedAdvertisingId = instance.cachedAdvertisingId;
-        expect(cachedAdvertisingId).to.equal(@"34629D8C-7B4F-4947-8E22-F1CC625889E5");
+        expect(cachedAdvertisingId).willNot.beNil();
     });
     
-    it(@"should properly store the cachedMarketingCloudId in NSUserDefaults", ^{
+    it(@"should have nil value for cachedMarketingCloudId in NSUserDefaults on clean install", ^{
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
         NSString *storedMarketingCloudId = [defaults stringForKey:@"com.segment.mcvid.marketingCloudId"];
-        expect(storedMarketingCloudId).to.equal(@"28682618302214414870104420606205106680");
+        expect(storedMarketingCloudId).to.beNil();
     });
     
     it(@"should properly store the cachedAdvertisingId in NSUserDefaults", ^{
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
         NSString *storedAdvertisingId = [defaults stringForKey:@"com.segment.mcvid.advertisingId"];
-        expect(storedAdvertisingId).to.equal(@"34629D8C-7B4F-4947-8E22-F1CC625889E5");
+        expect(storedAdvertisingId).willNot.beNil();
     });
     
     it(@"can make basic identify calls", ^{
@@ -112,9 +112,10 @@ describe(@"createURL function", ^{
         NSString const *syncIntegrationCallType = @"syncIntegrationCode";
         NSURL *url = [instance createURL:syncIntegrationCallType integrationCode:@"DSID_20915"];
         NSString *urlString = url.absoluteString;
+        NSString *expected = [NSString stringWithFormat:@"%@%@", @"01", instance.cachedAdvertisingId];
+        NSString *actual = [[urlString componentsSeparatedByString:@"%"] objectAtIndex:1];
         
-        NSString *expected = @"https://dpm.demdex.net/id?d_ver=2&d_rtbd=json&dcs_region=6&d_orgid=B3CB46FC57C6C8F77F000101@AdobeOrg&d_mid=28682618302214414870104420606205106680&d_cid_ic=DSID_20915%0134629D8C-7B4F-4947-8E22-F1CC625889E5";
-        expect(urlString).to.equal(expected);
+        expect(actual).to.equal(expected);
     });
 
     it(@"can properly create the getMarketingCloudId url", ^{
@@ -142,6 +143,9 @@ describe(@"buildIntegrationObject Function", ^{
         configuration.trackApplicationLifecycleEvents = YES;
         [SEGAnalytics setupWithConfiguration:configuration];
         instance = [[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region];
+        [[SEGAnalytics sharedAnalytics] track:@"Product Rated"
+                                   properties:nil
+                                      options:@{ @"integrations": @{ @"All": @YES, @"Mixpanel": @NO }}];
     });
     
     it(@"properly updates an empty integrations object with the marketingCloudId", ^{

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -148,6 +148,36 @@ describe(@"buildIntegrationObject Function", ^{
                                       options:@{ @"integrations": @{ @"All": @YES, @"Mixpanel": @NO }}];
     });
     
+    it(@"will not set marketingCloudVisitorId on clean install and not block events", ^{
+        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
+        NSDictionary *exisintgIntegrations = [NSDictionary new];
+        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
+        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
+        NSString *marketingCloudId = integrations[@"Adobe Analytics"][@"marketingCloudVisitorId"];
+        expect(marketingCloudId).to.beNil();
+    });
+    
+    it(@"properly updates an empty integrations object with the marketingCloudId", ^{
+        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
+        NSDictionary *exisintgIntegrations = [NSDictionary new];
+        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
+        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
+        NSString *marketingCloudId = integrations[@"Adobe Analytics"][@"marketingCloudVisitorId"];
+        expect(marketingCloudId).to.equal(instance.cachedMarketingCloudId);
+    });
+    
+    it(@"updates an empty integrations object with one k/v pair", ^{
+        NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                 @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
+        NSDictionary *exisintgIntegrations = [NSDictionary new];
+        SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
+        NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
+        NSInteger count = [integrations count];
+        expect(count).to.equal(1);
+    });
+    
     it(@"properly updates an integrations object with other integration specific options with the marketingCloudId", ^{
         NSDictionary *context = [[NSDictionary alloc] initWithObjectsAndKeys:
                                  @"Item Purchased", @"event", @{ @"item": @"Sword of Heracles", @"revenue": @2.95 }, @"properties", nil];
@@ -155,7 +185,7 @@ describe(@"buildIntegrationObject Function", ^{
         SEGPayload *payload = [[SEGPayload alloc] initWithContext:context integrations:exisintgIntegrations];
         NSMutableDictionary *integrations = [instance buildIntegrationsObject:payload];
         NSString *marketingCloudId = integrations[@"Adobe Analytics"][@"marketingCloudVisitorId"];
-        expect(marketingCloudId).willNot.beNil();
+        expect(marketingCloudId).to.equal(instance.cachedMarketingCloudId);
     });
     
     it(@"properly updates an integrations object with other integration specific options with the marketingCloudId", ^{

--- a/Example/analytics-ios-mcvid.xcodeproj/project.pbxproj
+++ b/Example/analytics-ios-mcvid.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		9672A38C342DB1BA4976FF7D /* libPods-analytics-ios-mcvid_Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F365941B6D1669BA8A426FCC /* libPods-analytics-ios-mcvid_Tests.a */; };
 		D8B7DDEA0882883BEC5A2CCA /* libPods-analytics-ios-mcvid_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9005D5F84F1E6D7D9446AE69 /* libPods-analytics-ios-mcvid_Example.a */; };
+		EAB557B122C3E1C000C4F5F1 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB557B022C3E1C000C4F5F1 /* AdSupport.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,7 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		067A5F01093BE1FE1292EAD0 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		067A5F01093BE1FE1292EAD0 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		4E51670D92D3474438551ECF /* Pods-analytics-ios-mcvid_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-analytics-ios-mcvid_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-analytics-ios-mcvid_Tests/Pods-analytics-ios-mcvid_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* analytics-ios-mcvid_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "analytics-ios-mcvid_Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -60,12 +61,13 @@
 		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
 		611E07E077212F112CE02503 /* Pods-analytics-ios-mcvid_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-analytics-ios-mcvid_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-analytics-ios-mcvid_Example/Pods-analytics-ios-mcvid_Example.release.xcconfig"; sourceTree = "<group>"; };
 		629A7257DFB50ABF2E7A9E88 /* Pods-analytics-ios-mcvid_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-analytics-ios-mcvid_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-analytics-ios-mcvid_Example/Pods-analytics-ios-mcvid_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		6E4DAB6C101D8BBD8D587DFA /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		6E4DAB6C101D8BBD8D587DFA /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		71719F9E1E33DC2100824A3D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8C20CAB2D3BD0A24ED91FF63 /* Pods-analytics-ios-mcvid_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-analytics-ios-mcvid_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-analytics-ios-mcvid_Tests/Pods-analytics-ios-mcvid_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		9005D5F84F1E6D7D9446AE69 /* libPods-analytics-ios-mcvid_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-analytics-ios-mcvid_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		AE747A19D9D86805DB95DE67 /* analytics-ios-mcvid.podspec */ = {isa = PBXFileReference; includeInIndex = 1; name = "analytics-ios-mcvid.podspec"; path = "../analytics-ios-mcvid.podspec"; sourceTree = "<group>"; };
+		AE747A19D9D86805DB95DE67 /* analytics-ios-mcvid.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "analytics-ios-mcvid.podspec"; path = "../analytics-ios-mcvid.podspec"; sourceTree = "<group>"; };
+		EAB557B022C3E1C000C4F5F1 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		F365941B6D1669BA8A426FCC /* libPods-analytics-ios-mcvid_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-analytics-ios-mcvid_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -74,6 +76,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EAB557B122C3E1C000C4F5F1 /* AdSupport.framework in Frameworks */,
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
@@ -130,6 +133,7 @@
 		6003F58C195388D20070C39A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				EAB557B022C3E1C000C4F5F1 /* AdSupport.framework */,
 				6003F58D195388D20070C39A /* Foundation.framework */,
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
@@ -256,6 +260,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Example/analytics-ios-mcvid/SEGAppDelegate.m
+++ b/Example/analytics-ios-mcvid/SEGAppDelegate.m
@@ -19,7 +19,7 @@
     SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:@"YOUR_WRITE_KEY"];
 
     // Configure the client with the MCVID middleware. Intiliaze with your Adobe OrgId and Adobe Region (ie. dcs_region key)
-    configuration.middlewares = @[ [[SEGMCVIDTracker alloc]  initWithOrganizationId:@"YOUR_ADOBE_ORGID@AdobeOrg" region:@"YOUR_REGION_HERE"] ];
+    configuration.middlewares = @[ [[SEGMCVIDTracker alloc]  initWithOrganizationId:@"YOUR_ADOBE_ORGID@AdobeOrg" region:@"OUR_REGION_HERE"] ];
     configuration.trackApplicationLifecycleEvents = YES; // Enable this to record certain application events automatically!
     configuration.recordScreenViews = YES; // Enable this to record screen views automatically!
     configuration.flushAt = 1; // Flush events to Segment every 1 event

--- a/Example/analytics-ios-mcvid/SEGAppDelegate.m
+++ b/Example/analytics-ios-mcvid/SEGAppDelegate.m
@@ -29,12 +29,8 @@
     [[SEGAnalytics sharedAnalytics] identify:@"user12345"
                                traits:@{ @"email": @"test@test.com" }];
 
-    [NSThread sleepForTimeInterval:5.0f];
-
    [[SEGAnalytics sharedAnalytics] track:@"Item Purchased"
                               properties:@{ @"item": @"Sword of Heracles", @"revenue": @2.95 }];
-
-    [NSThread sleepForTimeInterval:5.0f];
 
     [[SEGAnalytics sharedAnalytics] identify:@"Testing Adobe Analytics"];
 

--- a/Example/analytics-ios-mcvid/SEGAppDelegate.m
+++ b/Example/analytics-ios-mcvid/SEGAppDelegate.m
@@ -19,7 +19,7 @@
     SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:@"YOUR_WRITE_KEY"];
 
     // Configure the client with the MCVID middleware. Intiliaze with your Adobe OrgId and Adobe Region (ie. dcs_region key)
-    configuration.middlewares = @[ [[SEGMCVIDTracker alloc]  initWithOrganizationId:@"YOUR_ADOBE_ORGID@AdobeOrg" region:@"OUR_REGION_HERE"] ];
+    configuration.middlewares = @[ [[SEGMCVIDTracker alloc]  initWithOrganizationId:@"YOUR_ORD_ID@AdobeOrg" region:@"YOUR_REGION_KEY"] ];
     configuration.trackApplicationLifecycleEvents = YES; // Enable this to record certain application events automatically!
     configuration.recordScreenViews = YES; // Enable this to record screen views automatically!
     configuration.flushAt = 1; // Flush events to Segment every 1 event
@@ -33,6 +33,14 @@
                               properties:@{ @"item": @"Sword of Heracles", @"revenue": @2.95 }];
 
     [[SEGAnalytics sharedAnalytics] identify:@"Testing Adobe Analytics"];
+
+    [[SEGAnalytics sharedAnalytics] track:@"Product Rated"
+                           properties:nil
+                              options:@{ @"integrations": @{ @"All": @YES, @"Mixpanel": @NO }}];
+
+      [[SEGAnalytics sharedAnalytics] track:@"Product Removed"
+                             properties:nil
+                                options:@{ @"integrations": @{ @"All": @YES, @"Mixpanel": @NO, @"Adobe Analytics":@{ @"prop1":@"Hello World"} }}];
 
     return YES;
 }

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -3,19 +3,18 @@
 
 @interface SEGMCVIDTracker : NSObject <SEGMiddleware>
 
--(id)initWithOrganizationId:(NSString *)organizationId region:(NSString *)region;
+-(id _Nonnull)initWithOrganizationId:(NSString *_Nonnull)organizationId region:(NSString *_Nonnull)region;
 
-@property (nonatomic, strong) NSString *organizationId;
-@property (nonatomic, strong) NSString *region;
-@property dispatch_queue_t backgroundQueue;
+@property (nonatomic, strong, nonnull) NSString *organizationId;
+@property (nonatomic, strong, nonnull) NSString *region;
+@property dispatch_queue_t _Nonnull backgroundQueue;
 
-- (void) syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId completion:(void (^)(NSError *))completion;
-- (void)syncIntegrationCode:(NSString *)integrationCode userIdentifier:(NSString *)userIdentifier completion:(void (^)(NSError *))completion;
+- (void)syncIntegrationCode:(NSString *_Nonnull)integrationCode userIdentifier:(NSString *_Nonnull)userIdentifier completion:(void (^_Nonnull)(NSError *_Nullable))completion;
 
 @end
 
 // Use this key to retrieve the MCVIDAdobeError object from the NSError's userInfo dictionary
-extern NSString *const MCVIDAdobeErrorKey;
+extern NSString * _Nonnull const MCVIDAdobeErrorKey;
 
 typedef NS_ENUM(NSInteger, MCVIDAdobeErrorCode) {
     // Unable to deserialize JSON from response
@@ -27,7 +26,7 @@ typedef NS_ENUM(NSInteger, MCVIDAdobeErrorCode) {
 @interface MCVIDAdobeError : NSObject
 
 @property (nonatomic, assign) MCVIDAdobeErrorCode code;
-@property (nonatomic) NSString *message;
-@property (nonatomic) NSError *innerError;
+@property (nonatomic, nullable) NSString *message;
+@property (nonatomic, nullable) NSError *innerError;
 
 @end

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -16,7 +16,6 @@
 @property(nonatomic) NSUInteger *maxRetryTimeSecs;
 @property dispatch_queue_t backgroundQueue;
 
-+ (void) getMarketingCloudId:(NSString *)organizationId maxRetryCount:(NSUInteger)maxRetryCount currentRetryCount:(NSUInteger)currentRetryCount maxRetryTimeSecs:(NSUInteger)maxRetryTimeSecs completion:(void (^)(NSString *marketingCloudId, NSError *))completion;
 - (void) syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId marketingCloudId:(NSString *)marketingCloudId maxRetryCount:(NSUInteger)maxRetryCount currentRetryCount:(NSUInteger)currentRetryCount maxRetryTimeSecs:(NSUInteger)maxRetryTimeSecs completion:(void (^)(NSError *))completion;
 
 @end

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -1,7 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGMiddleware.h>
 
-
 @interface SEGMCVIDTracker : NSObject <SEGMiddleware>
 
 -(id)initWithOrganizationId:(NSString *)organizationId region:(NSString *)region;
@@ -14,7 +13,7 @@
 @property(nonatomic) NSString *cachedMarketingCloudId;
 
 
-- (void) getMarketingCloudId:(NSString *)organizationId completion:(void (^)(NSString *marketingCloudId, NSError *))completion;
++ (void) getMarketingCloudId:(NSString *)organizationId completion:(void (^)(NSString *marketingCloudId, NSError *))completion;
 - (void) syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId marketingCloudId:(NSString *)marketingCloudId completion:(void (^)(NSError *))completion;
 
 @end

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -9,7 +9,8 @@
 @property (nonatomic, strong) NSString *region;
 @property dispatch_queue_t backgroundQueue;
 
-- (void) syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId marketingCloudId:(NSString *)marketingCloudId completion:(void (^)(NSError *))completion;
+- (void) syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId completion:(void (^)(NSError *))completion;
+- (void)syncIntegrationCode:(NSString *)integrationCode userIdentifier:(NSString *)userIdentifier completion:(void (^)(NSError *))completion;
 
 @end
 

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -18,8 +18,6 @@
 extern NSString *const MCVIDAdobeErrorKey;
 
 typedef NS_ENUM(NSInteger, MCVIDAdobeErrorCode) {
-    // Network request failed
-    MCVIDAdobeErrorCodeClientFailedRequestError,
     // Unable to deserialize JSON from response
     MCVIDAdobeErrorCodeClientSerializationError,
     // An error was provided by the server

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -11,12 +11,12 @@
 @property(nonatomic, strong) NSString *staticMarketingCloudId;
 @property(nonatomic) NSString *cachedAdvertisingId;
 @property(nonatomic) NSString *cachedMarketingCloudId;
-@property(nonatomic) NSUInteger *maxRetryCount;
-@property(nonatomic) NSUInteger *currentRetryCount;
-@property(nonatomic) NSUInteger *maxRetryTimeSecs;
+//@property(nonatomic) NSUInteger *maxRetryCount;
+//@property(nonatomic) NSUInteger *currentRetryCount;
+//@property(nonatomic) NSUInteger *maxRetryTimeSecs;
 @property dispatch_queue_t backgroundQueue;
 
-- (void) syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId marketingCloudId:(NSString *)marketingCloudId maxRetryCount:(NSUInteger)maxRetryCount currentRetryCount:(NSUInteger)currentRetryCount maxRetryTimeSecs:(NSUInteger)maxRetryTimeSecs completion:(void (^)(NSError *))completion;
+- (void) syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId marketingCloudId:(NSString *)marketingCloudId completion:(void (^)(NSError *))completion;
 
 @end
 

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -7,7 +7,6 @@
 
 @property (nonatomic, strong, nonnull) NSString *organizationId;
 @property (nonatomic, strong, nonnull) NSString *region;
-@property dispatch_queue_t _Nonnull backgroundQueue;
 
 - (void)syncIntegrationCode:(NSString *_Nonnull)integrationCode userIdentifier:(NSString *_Nonnull)userIdentifier completion:(void (^_Nonnull)(NSError *_Nullable))completion;
 

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -11,9 +11,13 @@
 @property(nonatomic, strong) NSString *staticMarketingCloudId;
 @property(nonatomic) NSString *cachedAdvertisingId;
 @property(nonatomic) NSString *cachedMarketingCloudId;
+@property(nonatomic) NSInteger *maxRetryCount;
+@property(nonatomic) NSInteger *maxRetryTime;
+@property dispatch_queue_t backgroundQueue;
 
 
-+ (void) getMarketingCloudId:(NSString *)organizationId completion:(void (^)(NSString *marketingCloudId, NSError *))completion;
+
++ (void) getMarketingCloudId:(NSString *)organizationId maxRetryCount:(NSUInteger)maxRetryCount maxRetryTime:(NSUInteger)maxRetryTime completion:(void (^)(NSString *marketingCloudId, NSError *))completion;
 - (void) syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId marketingCloudId:(NSString *)marketingCloudId completion:(void (^)(NSError *))completion;
 
 @end

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -10,8 +10,12 @@
 @property (nonatomic, strong) NSString *region;
 @property(readonly, copy) NSString *stringByRemovingPercentEncoding;
 @property(nonatomic, strong) NSString *staticMarketingCloudId;
+@property(nonatomic) NSString *cachedAdvertisingId;
+@property(nonatomic) NSString *cachedMarketingCloudId;
 
-- (void) sendRequestAdobeExperienceCloud:(NSString *)advertiserId organizationId:(NSString *)organizationId completion:(void (^)(NSString *marketingCloudIdKey, NSError *))completion;
+
+- (void) getMarketingCloudId:(NSString *)organizationId completion:(void (^)(NSString *marketingCloudId, NSError *))completion;
+- (void) syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId marketingCloudId:(NSString *)marketingCloudId completion:(void (^)(NSError *))completion;
 
 @end
 

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -11,14 +11,13 @@
 @property(nonatomic, strong) NSString *staticMarketingCloudId;
 @property(nonatomic) NSString *cachedAdvertisingId;
 @property(nonatomic) NSString *cachedMarketingCloudId;
-@property(nonatomic) NSInteger *maxRetryCount;
-@property(nonatomic) NSInteger *maxRetryTime;
+@property(nonatomic) NSUInteger *maxRetryCount;
+@property(nonatomic) NSUInteger *currentRetryCount;
+@property(nonatomic) NSUInteger *maxRetryTimeSecs;
 @property dispatch_queue_t backgroundQueue;
 
-
-
-+ (void) getMarketingCloudId:(NSString *)organizationId maxRetryCount:(NSUInteger)maxRetryCount maxRetryTime:(NSUInteger)maxRetryTime completion:(void (^)(NSString *marketingCloudId, NSError *))completion;
-- (void) syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId marketingCloudId:(NSString *)marketingCloudId completion:(void (^)(NSError *))completion;
++ (void) getMarketingCloudId:(NSString *)organizationId maxRetryCount:(NSUInteger)maxRetryCount currentRetryCount:(NSUInteger)currentRetryCount maxRetryTimeSecs:(NSUInteger)maxRetryTimeSecs completion:(void (^)(NSString *marketingCloudId, NSError *))completion;
+- (void) syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId marketingCloudId:(NSString *)marketingCloudId maxRetryCount:(NSUInteger)maxRetryCount currentRetryCount:(NSUInteger)currentRetryCount maxRetryTimeSecs:(NSUInteger)maxRetryTimeSecs completion:(void (^)(NSError *))completion;
 
 @end
 

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -7,13 +7,6 @@
 
 @property (nonatomic, strong) NSString *organizationId;
 @property (nonatomic, strong) NSString *region;
-@property(readonly, copy) NSString *stringByRemovingPercentEncoding;
-@property(nonatomic, strong) NSString *staticMarketingCloudId;
-@property(nonatomic) NSString *cachedAdvertisingId;
-@property(nonatomic) NSString *cachedMarketingCloudId;
-//@property(nonatomic) NSUInteger *maxRetryCount;
-//@property(nonatomic) NSUInteger *currentRetryCount;
-//@property(nonatomic) NSUInteger *maxRetryTimeSecs;
 @property dispatch_queue_t backgroundQueue;
 
 - (void) syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId marketingCloudId:(NSString *)marketingCloudId completion:(void (^)(NSError *))completion;

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -141,8 +141,7 @@ NSString *const syncIntegrationCallType = @"syncIntegrationCode";
             dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * secondsToWait);
             dispatch_after(delay, self.backgroundQueue, ^(void){
                 self.currentRetryCount = self.currentRetryCount + 1;
-                [self getMarketingCloudId:organizationId completion:^(NSString * _Nullable marketingCloudId, NSError * _Nullable error) {
-                }];
+                [self getMarketingCloudId:organizationId completion:completion];
             });
         }
     }] resume];

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -58,10 +58,10 @@
     [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
     //This is was SEGIDFA() is going under the hood. NSString *idfaString = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
     NSString *segIdfa = SEGIDFA();
-    _cachedMarketingCloudId = [defaults stringForKey:@"MarketingCloudId"];
+    _cachedMarketingCloudId = [defaults stringForKey:@"com.segment.mcvid.marketingCloudId"];
     if (![_cachedAdvertisingId isEqualToString:segIdfa]) {
-        [defaults setObject:segIdfa forKey:@"AdvertisingId"];
-        _cachedAdvertisingId = [defaults stringForKey:@"AdvertisingId"];
+        [defaults setObject:segIdfa forKey:@"com.segment.mcvid.advertisingId"];
+        _cachedAdvertisingId = [defaults stringForKey:@"com.segment.mcvid.advertisingId"];
     }
     
     
@@ -70,7 +70,7 @@
 
     if (self.cachedMarketingCloudId.length == 0 || (segIdfa != self.cachedAdvertisingId)) {
         [self getMarketingCloudId:organizationId completion:^(NSString *marketingCloudId, NSError *error) {
-          [defaults setObject:marketingCloudId forKey:@"MarketingCloudId"];
+          [defaults setObject:marketingCloudId forKey:@"com.segment.mcvid.marketingCloudId"];
             [self syncIntegrationCode:integrationCode userIdentifier:self.cachedAdvertisingId completion:^(NSError *error) {
               if (error) {
                   return;

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -8,8 +8,8 @@
 NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
 NSString *const getCloudIdCallType = @"getMarketingCloudID";
 NSString *const syncIntegrationCallType = @"syncIntegrationCode";
-NSString *const cachedMarketingCloudIdKey = @"syncIntegrationCode";
-NSString *const cachedAdvertisingIdKey = @"syncIntegrationCode";
+NSString *const cachedMarketingCloudIdKey = @"com.segment.mcvid.marketingCloudId";
+NSString *const cachedAdvertisingIdKey = @"com.segment.mcvid.advertisingId";
 
 
 @interface MCVIDAdobeError ()

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -8,6 +8,9 @@
 NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
 NSString *const getCloudIdCallType = @"getMarketingCloudID";
 NSString *const syncIntegrationCallType = @"syncIntegrationCode";
+NSString *const cachedMarketingCloudIdKey = @"syncIntegrationCode";
+NSString *const cachedAdvertisingIdKey = @"syncIntegrationCode";
+
 
 @interface MCVIDAdobeError ()
 
@@ -59,18 +62,18 @@ NSString *const syncIntegrationCallType = @"syncIntegrationCode";
     //Store advertisingId and marketingCloudId on local storage
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSString *segIdfa = SEGIDFA();
-    _cachedMarketingCloudId = [defaults stringForKey:@"com.segment.mcvid.marketingCloudId"];
+    _cachedMarketingCloudId = [defaults stringForKey:cachedMarketingCloudIdKey];
     if (_cachedAdvertisingId == NULL) {
-        [defaults setObject:segIdfa forKey:@"com.segment.mcvid.advertisingId"];
-        _cachedAdvertisingId = [defaults stringForKey:@"com.segment.mcvid.advertisingId"];
+        [defaults setObject:segIdfa forKey:cachedAdvertisingIdKey];
+        _cachedAdvertisingId = [defaults stringForKey:cachedAdvertisingIdKey];
     }
     //Defaut value for integration code which indicate ios
     NSString *integrationCode = @"DSID_20915";
 
     if (self.cachedMarketingCloudId.length == 0) {
         [self getMarketingCloudId:organizationId completion:^(NSString  * _Nullable marketingCloudId, NSError * _Nullable error) {
-          [defaults setObject:marketingCloudId forKey:@"com.segment.mcvid.marketingCloudId"];
-            self.cachedMarketingCloudId = [defaults stringForKey:@"com.segment.mcvid.marketingCloudId"];
+          [defaults setObject:marketingCloudId forKey:cachedMarketingCloudIdKey];
+            self.cachedMarketingCloudId = [defaults stringForKey:cachedMarketingCloudIdKey];
             [self syncIntegrationCode:integrationCode userIdentifier:self.cachedAdvertisingId completion:^(NSError *error) {
               if (error) {
                   return;

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -200,7 +200,11 @@ NSString *const syncIntegrationCallType = @"syncIntegrationCode";
     }] resume];
 }
 
-- (NSURL * _Nonnull)createURL:(NSString *_Nonnull)callType integrationCode:(NSString * _Nonnull)integrationCode {
+- (NSURL * _Nonnull)createURL:callType integrationCode:(NSString * _Nonnull)integrationCode {
+    return [self createURL:callType integrationCode:integrationCode userIdentifier:self.cachedAdvertisingId];
+}
+
+- (NSURL * _Nonnull)createURL:(NSString *_Nonnull)callType integrationCode:(NSString * _Nonnull)integrationCode userIdentifier:(NSString* _Nullable)userIdentifier {
     //Variables to build URL for GET request
     NSString *protocol = @"https";
     NSString *host = @"dpm.demdex.net";
@@ -232,7 +236,7 @@ NSString *const syncIntegrationCallType = @"syncIntegrationCode";
 
     if ([callType isEqualToString:@"syncIntegrationCode"]) {
         [queryItems addObject:[NSURLQueryItem queryItemWithName:marketingCloudIdKey value:self.cachedMarketingCloudId]];
-        NSString *encodedAdvertisingValue = [NSString stringWithFormat:@"%@%@%@", integrationCode, separator, self.cachedAdvertisingId];
+        NSString *encodedAdvertisingValue = [NSString stringWithFormat:@"%@%@%@", integrationCode, separator, userIdentifier];
         //removes %25 html encoding of '%'
         NSString *normalAdvertisingValue = [encodedAdvertisingValue stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
         [queryItems addObject:[NSURLQueryItem queryItemWithName:advertisingIdKey value:normalAdvertisingValue]];

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -200,7 +200,7 @@ NSString *const syncIntegrationCallType = @"syncIntegrationCode";
     }] resume];
 }
 
-- (NSURL * _Nonnull)createURL:callType integrationCode:(NSString * _Nonnull)integrationCode {
+- (NSURL * _Nonnull)createURL:(NSString *_Nonnull)callType integrationCode:(NSString * _Nonnull)integrationCode {
     //Variables to build URL for GET request
     NSString *protocol = @"https";
     NSString *host = @"dpm.demdex.net";

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -161,9 +161,12 @@
   }
 
   if (!self.staticMarketingCloudId) {
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
     [self sendRequestAdobeExperienceCloud:advertisingId organizationId:organizationId completion:^(NSString *marketingCloudId, NSError *error) {
       self.staticMarketingCloudId = marketingCloudId;
+      dispatch_semaphore_signal(sema);
     }];
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
   }
 
   if (self.staticMarketingCloudId.length) {

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -30,7 +30,6 @@ NSString *const syncIntegrationCallType = @"syncIntegrationCode";
 @interface SEGMCVIDTracker()
     @property(nonatomic) NSUInteger maxRetryCount;
     @property(nonatomic) NSUInteger currentRetryCount;
-    @property(nonatomic) NSUInteger maxRetryTimeSecs;
     @property(nonatomic, nonnull) NSString *cachedMarketingCloudId;
     @property(nonatomic, nonnull) NSString *cachedAdvertisingId;
     @property dispatch_queue_t _Nonnull backgroundQueue;
@@ -54,7 +53,6 @@ NSString *const syncIntegrationCallType = @"syncIntegrationCode";
     //Values for exponential backoff retry logic for API calls
     _maxRetryCount = 11;
     _currentRetryCount = 1;
-    _maxRetryTimeSecs = 300;
     self.backgroundQueue = dispatch_queue_create("com.segment.mcvid", NULL);
 
 

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -266,49 +266,48 @@ NSString *const cachedAdvertisingIdKey = @"syncIntegrationCode";
     SEGScreenPayload *screen =(SEGScreenPayload *)context.payload;
     SEGGroupPayload *group =(SEGGroupPayload *)context.payload;
   
-    NSMutableDictionary *adobeOptions = [NSMutableDictionary new];
-
     if ([context.payload isKindOfClass:[SEGIdentifyPayload class]]){
-        if ((identify.integrations != NULL) && ([identify.integrations objectForKey:@"Adobe Analytics"])){
-            NSDictionary *existingAAOptions = identify.integrations[@"Adobe Analytics"];
-            [adobeOptions addEntriesFromDictionary:existingAAOptions];
-            [adobeOptions setObject:self.cachedMarketingCloudId forKey:@"marketingCloudVisitorId"];
-        }
-        
         NSMutableDictionary *integrations = [NSMutableDictionary new];
-        if (identify.integrations != NULL) {
-            NSMutableDictionary *existingIntegrations = [NSMutableDictionary new];
-            [existingIntegrations addEntriesFromDictionary:identify.integrations];
-            [existingIntegrations removeObjectForKey:@"Adobe Analytics"];
-            [integrations addEntriesFromDictionary:existingIntegrations];
-            [integrations setObject:adobeOptions forKey:@"Adobe Analytics"];
+        
+        NSMutableDictionary *adobeOptions = [identify.integrations[@"Adobe Analytics"] mutableCopy];
+        if (!adobeOptions) {
+            adobeOptions = [NSMutableDictionary new];
         }
+        [adobeOptions setObject:self.cachedMarketingCloudId forKey:@"marketingCloudVisitorId"];
+        
+        if (identify.integrations != nil) {
+            NSMutableDictionary *existingIntegrations = [identify.integrations mutableCopy];
+            [existingIntegrations removeObjectForKey:@"AdobeAnalytics"];
+            [integrations addEntriesFromDictionary:existingIntegrations];
+        }
+        [integrations setObject:adobeOptions forKey:@"Adobe Analytics"];
+        
         SEGContext *newIdentifyContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
             ctx.payload = [[SEGIdentifyPayload alloc] initWithUserId:identify.userId
-                                                    anonymousId:identify.anonymousId
-                                                    traits: identify.traits
-                                                    context:identify.context
-                                                    integrations: integrations];
-                                                  }];
-
+                                                         anonymousId:identify.anonymousId
+                                                              traits: identify.traits
+                                                             context:identify.context
+                                                        integrations: integrations];
+        }];
+        
         next(newIdentifyContext);
     }
 
     if ([context.payload isKindOfClass:[SEGTrackPayload class]]){
-        if ((track.integrations != NULL) && ([track.integrations objectForKey:@"Adobe Analytics"])){
-            NSDictionary *existingAAOptions = track.integrations[@"Adobe Analytics"];
-            [adobeOptions addEntriesFromDictionary:existingAAOptions];
-            [adobeOptions setObject:self.cachedMarketingCloudId forKey:@"marketingCloudVisitorId"];
-        }
-        
         NSMutableDictionary *integrations = [NSMutableDictionary new];
-        if (track.integrations != NULL) {
-            NSMutableDictionary *existingIntegrations = [NSMutableDictionary new];
-            [existingIntegrations addEntriesFromDictionary:track.integrations];
-            [existingIntegrations removeObjectForKey:@"Adobe Analytics"];
-            [integrations addEntriesFromDictionary:existingIntegrations];
-            [integrations setObject:adobeOptions forKey:@"Adobe Analytics"];
+        
+        NSMutableDictionary *adobeOptions = [track.integrations[@"Adobe Analytics"] mutableCopy];
+        if (!adobeOptions) {
+            adobeOptions = [NSMutableDictionary new];
         }
+        [adobeOptions setObject:self.cachedMarketingCloudId forKey:@"marketingCloudVisitorId"];
+        
+        if (track.integrations != nil) {
+            NSMutableDictionary *existingIntegrations = [track.integrations mutableCopy];
+            [existingIntegrations removeObjectForKey:@"AdobeAnalytics"];
+            [integrations addEntriesFromDictionary:existingIntegrations];
+        }
+        [integrations setObject:adobeOptions forKey:@"Adobe Analytics"];
 
         SEGContext *newTrackContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
           ctx.payload = [[SEGTrackPayload alloc] initWithEvent:track.event
@@ -320,20 +319,20 @@ NSString *const cachedAdvertisingIdKey = @"syncIntegrationCode";
     }
 
     if ([context.payload isKindOfClass:[SEGScreenPayload class]]){
-        if ((screen.integrations != NULL) && ([screen.integrations objectForKey:@"Adobe Analytics"])){
-            NSDictionary *existingAAOptions = screen.integrations[@"Adobe Analytics"];
-            [adobeOptions addEntriesFromDictionary:existingAAOptions];
-            [adobeOptions setObject:self.cachedMarketingCloudId forKey:@"marketingCloudVisitorId"];
-        }
-        
         NSMutableDictionary *integrations = [NSMutableDictionary new];
-        if (screen.integrations != NULL) {
-            NSMutableDictionary *existingIntegrations = [NSMutableDictionary new];
-            [existingIntegrations addEntriesFromDictionary:screen.integrations];
-            [existingIntegrations removeObjectForKey:@"Adobe Analytics"];
-            [integrations addEntriesFromDictionary:existingIntegrations];
-            [integrations setObject:adobeOptions forKey:@"Adobe Analytics"];
+        
+        NSMutableDictionary *adobeOptions = [screen.integrations[@"Adobe Analytics"] mutableCopy];
+        if (!adobeOptions) {
+            adobeOptions = [NSMutableDictionary new];
         }
+        [adobeOptions setObject:self.cachedMarketingCloudId forKey:@"marketingCloudVisitorId"];
+        
+        if (screen.integrations != nil) {
+            NSMutableDictionary *existingIntegrations = [screen.integrations mutableCopy];
+            [existingIntegrations removeObjectForKey:@"AdobeAnalytics"];
+            [integrations addEntriesFromDictionary:existingIntegrations];
+        }
+        [integrations setObject:adobeOptions forKey:@"Adobe Analytics"];
         
         SEGContext *newScreenContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
           ctx.payload = [[SEGScreenPayload alloc] initWithName:screen.name
@@ -345,20 +344,20 @@ NSString *const cachedAdvertisingIdKey = @"syncIntegrationCode";
     }
 
     if ([context.payload isKindOfClass:[SEGGroupPayload class]]){
-        if ((group.integrations != NULL) && ([group.integrations objectForKey:@"Adobe Analytics"])){
-            NSDictionary *existingAAOptions = group.integrations[@"Adobe Analytics"];
-            [adobeOptions addEntriesFromDictionary:existingAAOptions];
-            [adobeOptions setObject:self.cachedMarketingCloudId forKey:@"marketingCloudVisitorId"];
-        }
-        
         NSMutableDictionary *integrations = [NSMutableDictionary new];
-        if (group.integrations != NULL) {
-            NSMutableDictionary *existingIntegrations = [NSMutableDictionary new];
-            [existingIntegrations addEntriesFromDictionary:group.integrations];
-            [existingIntegrations removeObjectForKey:@"Adobe Analytics"];
-            [integrations addEntriesFromDictionary:existingIntegrations];
-            [integrations setObject:adobeOptions forKey:@"Adobe Analytics"];
+        
+        NSMutableDictionary *adobeOptions = [group.integrations[@"Adobe Analytics"] mutableCopy];
+        if (!adobeOptions) {
+            adobeOptions = [NSMutableDictionary new];
         }
+        [adobeOptions setObject:self.cachedMarketingCloudId forKey:@"marketingCloudVisitorId"];
+        
+        if (group.integrations != nil) {
+            NSMutableDictionary *existingIntegrations = [group.integrations mutableCopy];
+            [existingIntegrations removeObjectForKey:@"AdobeAnalytics"];
+            [integrations addEntriesFromDictionary:existingIntegrations];
+        }
+        [integrations setObject:adobeOptions forKey:@"Adobe Analytics"];
         
         SEGContext *newGroupContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
           ctx.payload = [[SEGGroupPayload alloc] initWithGroupId:group.groupId

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -63,9 +63,10 @@ NSString *const cachedAdvertisingIdKey = @"syncIntegrationCode";
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSString *segIdfa = SEGIDFA();
     _cachedMarketingCloudId = [defaults stringForKey:cachedMarketingCloudIdKey];
+    _cachedAdvertisingId = [defaults stringForKey:cachedAdvertisingIdKey];
     if (_cachedAdvertisingId == NULL) {
         [defaults setObject:segIdfa forKey:cachedAdvertisingIdKey];
-        _cachedAdvertisingId = [defaults stringForKey:cachedAdvertisingIdKey];
+        _cachedAdvertisingId = segIdfa;
     }
     //Defaut value for integration code which indicate ios
     NSString *integrationCode = @"DSID_20915";

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -35,7 +35,6 @@
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSString *cachedMarketingCloudId = [defaults stringForKey:@"MarketingCloudId"];
-    [defaults setObject:advertisingId forKey:@"AdvertisingId"];
     NSString *cachedAdvertisingId = [defaults stringForKey:@"AdvertisingId"];
 
     if (!cachedMarketingCloudId || (cachedAdvertisingId != SEGIDFA())) {

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -31,6 +31,8 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
     @property(nonatomic) NSUInteger maxRetryTimeSecs;
     @property(nonatomic, nonnull) NSString *cachedMarketingCloudId;
     @property(nonatomic, nonnull) NSString *cachedAdvertisingId;
+    @property dispatch_queue_t _Nonnull backgroundQueue;
+
 @end
 
 @implementation SEGMCVIDTracker

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -193,8 +193,7 @@ NSString *const syncIntegrationCallType = @"syncIntegrationCode";
             dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * secondsToWait);
             dispatch_after(delay, self.backgroundQueue, ^(void){
                 self.currentRetryCount = self.currentRetryCount + 1;
-                [self syncIntegrationCode:integrationCode userIdentifier:self.cachedAdvertisingId completion:^(NSError * _Nullable error){
-                }];
+                [self syncIntegrationCode:integrationCode userIdentifier:self.cachedAdvertisingId completion:completion];
             });
         }
     }] resume];

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -252,21 +252,20 @@ NSString *const cachedAdvertisingIdKey = @"syncIntegrationCode";
 
 - (void)context:(SEGContext *_Nonnull)context next:(SEGMiddlewareNext _Nonnull)next {
     if ([context.payload isKindOfClass:[SEGAliasPayload class]]) {
-      next(context);
-      return;
+        next(context);
+        return;
+    }
+    
+    if (self.cachedMarketingCloudId.length == 0) {
+        next(context);
+        return;
     }
 
-  if (!self.cachedMarketingCloudId) {
-    next(context);
-    return;
-  }
-
-  SEGIdentifyPayload *identify =(SEGIdentifyPayload *)context.payload;
-  SEGTrackPayload *track =(SEGTrackPayload *)context.payload;
-  SEGScreenPayload *screen =(SEGScreenPayload *)context.payload;
-  SEGGroupPayload *group =(SEGGroupPayload *)context.payload;
-
-  if (self.cachedMarketingCloudId.length) {
+    SEGIdentifyPayload *identify =(SEGIdentifyPayload *)context.payload;
+    SEGTrackPayload *track =(SEGTrackPayload *)context.payload;
+    SEGScreenPayload *screen =(SEGScreenPayload *)context.payload;
+    SEGGroupPayload *group =(SEGGroupPayload *)context.payload;
+  
     NSMutableDictionary *adobeOptions = [NSMutableDictionary new];
 
     if ([context.payload isKindOfClass:[SEGIdentifyPayload class]]){
@@ -369,8 +368,8 @@ NSString *const cachedAdvertisingIdKey = @"syncIntegrationCode";
                                                 }];
         next(newGroupContext);
     }
+    
     return;
-  }
 }
 
 @end

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -58,8 +58,6 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
 
     //Store advertisingId and marketingCloudId on local storage
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
-    //This is was SEGIDFA() is going under the hood. NSString *idfaString = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
     NSString *segIdfa = SEGIDFA();
     _cachedMarketingCloudId = [defaults stringForKey:@"com.segment.mcvid.marketingCloudId"];
     if (_cachedAdvertisingId == NULL) {

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -145,7 +145,6 @@
 
   if ([context.payload isKindOfClass:[SEGIdentifyPayload class]]){
     advertisingId = identify.context[@"device"][@"advertistingId"];
-
   }
 
   if ([context.payload isKindOfClass:[SEGTrackPayload class]]){
@@ -153,12 +152,17 @@
   }
 
   if ([context.payload isKindOfClass:[SEGScreenPayload class]]){
-    advertisingId = screen.context[@"device"][@"advertistingId"];
+    advertisingId =  screen.context[@"device"][@"advertistingId"];
   }
 
   if ([context.payload isKindOfClass:[SEGGroupPayload class]]){
     advertisingId = group.context[@"device"][@"advertistingId"];
   }
+
+  if (!advertisingId){
+      advertisingId = SEGIDFA();
+  }
+
 
   if (!self.staticMarketingCloudId) {
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -6,6 +6,8 @@
 #include <math.h>
 
 NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
+NSString *const getCloudIdCallType = @"getMarketingCloudID";
+NSString *const syncIntegrationCallType = @"syncIntegrationCode";
 
 @interface MCVIDAdobeError ()
 
@@ -96,9 +98,7 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
     NSString *errorDomain = @"Segment-Adobe";
     NSString *marketingCloudIdKey = @"d_mid";
 
-    NSString *callType = @"getmMarketingCloudId";
-
-    NSURL *url = [self createURL:callType integrationCode:@"DSID_20915"];
+    NSURL *url = [self createURL:getCloudIdCallType integrationCode:@"DSID_20915"];
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
@@ -153,9 +153,8 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
     //Response and error handling variables
     NSString *errorResponseKey = @"errors";
     NSString *errorDomain = @"Segment-Adobe";
-    NSString *callType =@"syncIntegrationCode";
 
-    NSURL *url = [self createURL:callType integrationCode:integrationCode];
+    NSURL *url = [self createURL:syncIntegrationCallType integrationCode:integrationCode];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
     NSURLSession *session = [NSURLSession sessionWithConfiguration:config];

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -1,6 +1,8 @@
 #import "SEGMCVIDTracker.h"
 #import <Analytics/SEGAnalyticsUtils.h>
 #import <AdSupport/ASIdentifierManager.h>
+#include <time.h>
+#include <stdlib.h>
 
 
 
@@ -138,8 +140,11 @@
 
         NSString *marketingCloudId = dictionary[marketingCloudIdKey];
         NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
-        __block NSInteger responseStatusCode = 400;
-//        [httpResponse statusCode];
+        __block NSInteger responseStatusCode = [httpResponse statusCode];
+        srand(time(NULL));
+        int r = rand() % 2;
+        responseStatusCode = (r == 0) ? 200 : 400;
+        
 
         if ((responseStatusCode != 200) || ([marketingCloudId isEqualToString:invalidMarketingCloudId])){
            dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 10);
@@ -156,9 +161,9 @@
                    }];
                 }
             });
-               
+        } else {
+            completion(marketingCloudId, nil);
         }
-          completion(marketingCloudId, nil);
     }] resume];
 }
 

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -62,12 +62,10 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
     //This is was SEGIDFA() is going under the hood. NSString *idfaString = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
     NSString *segIdfa = SEGIDFA();
     _cachedMarketingCloudId = [defaults stringForKey:@"com.segment.mcvid.marketingCloudId"];
-    if (![_cachedAdvertisingId isEqualToString:segIdfa]) {
+    if (_cachedAdvertisingId == NULL) {
         [defaults setObject:segIdfa forKey:@"com.segment.mcvid.advertisingId"];
         _cachedAdvertisingId = [defaults stringForKey:@"com.segment.mcvid.advertisingId"];
     }
-
-
     //Defaut value for integration code which indicate ios
     NSString *integrationCode = @"DSID_20915";
 
@@ -81,7 +79,7 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
               }
           }];
         }];
-    } else if (self.cachedMarketingCloudId.length != 0) {
+    } else if (![_cachedAdvertisingId isEqualToString:segIdfa]) {
       [self syncIntegrationCode:integrationCode userIdentifier:self.cachedAdvertisingId completion:^(NSError * _Nullable error) {
           if (error) {
               return;

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -32,10 +32,35 @@
       self.organizationId = organizationId;
       self.region = region;
     }
+
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *cachedMarketingCloudId = [defaults stringForKey:@"MarketingCloudId"];
+    [defaults setObject:advertisingId forKey:@"AdvertisingId"];
+    NSString *cachedAdvertisingId = [defaults stringForKey:@"AdvertisingId"];
+
+    if (!cachedMarketingCloudId || (cachedAdvertisingId != SEGIDFA())) {
+      NSString *advertisingId = SEGIDFA();
+      [defaults setObject:advertisingId forKey:@"AdvertisingId"];
+      dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+        [self getMarketingCloudId:organizationId completion:^(NSString *marketingCloudId, NSError *error) {
+          [defaults setObject:marketingCloudId forKey:@"MarketingCloudId"];
+        }];
+
+        [self syncMarketingCloudId:cachedAdvertisingId organizationId:organizationId marketingCloudId:cachedMarketingCloudId completion:^(NSError *error) {
+          dispatch_semaphore_signal(sema);
+        }];
+      dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+    } else if (cachedMarketingCloudId && (cachedAdvertisingId == SEGIDFA()) && cachedAdvertisingId) {
+      dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+      [self syncMarketingCloudId:cachedAdvertisingId organizationId:organizationId marketingCloudId:cachedMarketingCloudId completion:^(NSError *error) {
+        dispatch_semaphore_signal(sema);
+      }];
+      dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+    }
     return self;
   }
 
-- (void)sendRequestAdobeExperienceCloud:(NSString *)advertisingId organizationId:(NSString *)organizationId completion:(void (^)(NSString *marketingCloudId, NSError *))completion {
+- (void)getMarketingCloudId:(NSString *)organizationId completion:(void (^)(NSString *marketingCloudId, NSError *))completion {
     //Variables to build URL for GET request
     NSString *protocol = @"https";
     NSString *host = @"dpm.demdex.net";
@@ -51,11 +76,6 @@
     NSString *marketingCloudIdKey = @"d_mid";
     NSString *organizationIdKey = @"d_orgid"; //can retrieve from settings
 
-    //Variables for when advertising Id is present
-    NSString *deviceTypeKey = @"DSID_20915";//means ios
-    NSString *separator = @"%01";
-    NSString *advertisingIdKey = @"d_cid_ic";
-
     //Values to build URl components and query items
     NSMutableString *urlString = [NSMutableString stringWithFormat:@"%@://%@%@", protocol, host, path];
     NSURLComponents *components = [NSURLComponents componentsWithString:urlString];
@@ -67,14 +87,6 @@
     NSString *invalidMarketingCloudId = @"<null>";
     NSString *errorDomain = @"Segment-Adobe";
     NSString *serverErrorDomain = @"Segment-Adobe Server Response";
-
-
-    if (advertisingId) {
-      NSString *encodedAdvertisingValue = [NSString stringWithFormat:@"%@%@%@", deviceTypeKey, separator, advertisingId];
-      //removes %25 html encoding of '%'
-      NSString *normalAdvertisingValue = [encodedAdvertisingValue stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-      [queryItems addObject:[NSURLQueryItem queryItemWithName:advertisingIdKey value:normalAdvertisingValue]];
-    }
 
     [queryItems addObject:[NSURLQueryItem queryItemWithName:versionKey value:version]];
     [queryItems addObject:[NSURLQueryItem queryItemWithName:jsonFormatterKey value:jsonFormatter]];
@@ -124,6 +136,87 @@
     }] resume];
 }
 
+- (void)syncMarketingCloudId:(NSString *)advertisingId organizationId:(NSString *)organizationId marketingCloudId:(NSString *)marketingCloudId completion:(void (^)(NSError *))completion {
+    //Variables to build URL for GET request
+    NSString *protocol = @"https";
+    NSString *host = @"dpm.demdex.net";
+    NSString *path = @"/id?";
+
+    //Defaulted values for request
+    NSString *versionKey = @"d_ver"; //d_ver defaults to 2
+    NSString *version = @"2"; //d_ver defaults to 2
+    NSString *jsonFormatterKey = @"d_rtbd";//&d_rtbd and defaults to = json
+    NSString *jsonFormatter = @"json";//&d_rtbd and defaults to = json
+    NSString *regionKey = @"dcs_region"; //dcs_region key defaults to = 6
+    NSString *region = _region; //dcs_region
+    NSString *marketingCloudIdKey = @"d_mid";
+    NSString *organizationIdKey = @"d_orgid"; //can retrieve from settings
+
+    //Variables for when advertising Id is present
+    NSString *deviceTypeKey = @"DSID_20915";//means ios
+    NSString *separator = @"%01";
+    NSString *advertisingIdKey = @"d_cid_ic";
+
+    //Values to build URl components and query items
+    NSMutableString *urlString = [NSMutableString stringWithFormat:@"%@://%@%@", protocol, host, path];
+    NSURLComponents *components = [NSURLComponents componentsWithString:urlString];
+    NSMutableArray *queryItems = [NSMutableArray array];
+
+    //Error handling variables
+    NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
+    NSString *errorResponseKey = @"error_msg";
+    NSString *errorDomain = @"Segment-Adobe";
+    NSString *serverErrorDomain = @"Segment-Adobe Server Response";
+
+    NSString *encodedAdvertisingValue = [NSString stringWithFormat:@"%@%@%@", deviceTypeKey, separator, advertisingId];
+    //removes %25 html encoding of '%'
+    NSString *normalAdvertisingValue = [encodedAdvertisingValue stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:advertisingIdKey value:normalAdvertisingValue]];
+
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:versionKey value:version]];
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:jsonFormatterKey value:jsonFormatter]];
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:regionKey value:region]];
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:organizationIdKey value:organizationId]];
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:marketingCloudIdKey value:marketingCloudId]];
+
+    components.queryItems = queryItems;
+    NSURL *url = components.URL;
+    NSLog(@"URL, %@", url);
+
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
+
+    [[session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+
+      void (^callbackWithCode)(MCVIDAdobeErrorCode code, NSString *message, NSError *error) = ^void(MCVIDAdobeErrorCode code, NSString *message, NSError *error) {
+            MCVIDAdobeError *adobeError = [[MCVIDAdobeError alloc] initWithCode:code message:message error:error];
+            NSError *compositeError = [NSError errorWithDomain:errorDomain code:adobeError.code userInfo:@{MCVIDAdobeErrorKey:adobeError}];
+            completion(compositeError);
+        };
+
+      if (error) {
+        return callbackWithCode(MCVIDAdobeErrorCodeClientFailedRequestError, @"Request Failed", error);
+      }
+
+        NSDictionary *dictionary = nil;
+        @try {
+            dictionary = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+        } @catch (NSException *exception) {
+            return callbackWithCode(MCVIDAdobeErrorCodeClientSerializationError, @"Deserializing the JSON response failed", nil);
+            return (NSLog(@"error"));
+        }
+
+        NSDictionary *errorDictionary = dictionary[errorResponseKey];
+        if (errorDictionary) {
+            NSError *error = [NSError errorWithDomain:serverErrorDomain code:0 userInfo:errorDictionary];
+            return callbackWithCode(MCVIDAdobeErrorCodeServerError, @"Server returned an error", error);
+        }
+
+        completion(nil);
+    }] resume];
+}
+
 
 - (void)context:(SEGContext *_Nonnull)context next:(SEGMiddlewareNext _Nonnull)next
 {
@@ -131,51 +224,28 @@
     next(context);
     return;
   }
-  NSString *organizationId = _organizationId;
-  NSString *advertisingId = nil;
-   SEGIdentifyPayload *identify =(SEGIdentifyPayload *)context.payload;
-   SEGTrackPayload *track =(SEGTrackPayload *)context.payload;
-   SEGScreenPayload *screen =(SEGScreenPayload *)context.payload;
-   SEGGroupPayload *group =(SEGGroupPayload *)context.payload;
 
-  if (!organizationId) {
-      next(context);
-      return;
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  NSString *cachedMarketingCloudId = [defaults stringForKey:@"MarketingCloudId"];
+  if (!cachedMarketingCloudId) {
+    next(context);
+    return;
   }
 
-  if ([context.payload isKindOfClass:[SEGIdentifyPayload class]]){
-    advertisingId = identify.context[@"device"][@"advertistingId"];
-  }
+ if (!_organizationId) {
+     next(context);
+     return;
+ }
 
-  if ([context.payload isKindOfClass:[SEGTrackPayload class]]){
-    advertisingId = track.context[@"device"][@"advertistingId"];
-  }
+  SEGIdentifyPayload *identify =(SEGIdentifyPayload *)context.payload;
+  SEGTrackPayload *track =(SEGTrackPayload *)context.payload;
+  SEGScreenPayload *screen =(SEGScreenPayload *)context.payload;
+  SEGGroupPayload *group =(SEGGroupPayload *)context.payload;
 
-  if ([context.payload isKindOfClass:[SEGScreenPayload class]]){
-    advertisingId =  screen.context[@"device"][@"advertistingId"];
-  }
-
-  if ([context.payload isKindOfClass:[SEGGroupPayload class]]){
-    advertisingId = group.context[@"device"][@"advertistingId"];
-  }
-
-  if (!advertisingId){
-      advertisingId = SEGIDFA();
-  }
-
-
-  if (!self.staticMarketingCloudId) {
-    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-    [self sendRequestAdobeExperienceCloud:advertisingId organizationId:organizationId completion:^(NSString *marketingCloudId, NSError *error) {
-      self.staticMarketingCloudId = marketingCloudId;
-      dispatch_semaphore_signal(sema);
-    }];
-    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
-  }
-
-  if (self.staticMarketingCloudId.length) {
-    NSMutableDictionary *mergedIntegrations = [NSMutableDictionary dictionaryWithCapacity:(identify.integrations.count || track.integrations.count || screen.integrations.count || group.integrations.count) + 1 ];
-    NSDictionary *mcidIntegrations = @{@"Adobe Analytics" : @{ @"marketingCloudVisitorId": self.staticMarketingCloudId } };
+  if (cachedMarketingCloudId.length) {
+    NSMutableDictionary *mergedIntegrations = [NSMutableDictionary dictionaryWithCapacity:100];
+    NSDictionary *mcidIntegrations = @{@"Adobe Analytics" : @{ @"marketingCloudVisitorId": cachedMarketingCloudId } };
+    NSLog(@"mcidIntegrations %@", mcidIntegrations);
     [mergedIntegrations addEntriesFromDictionary:mcidIntegrations];
 
     if ([context.payload isKindOfClass:[SEGIdentifyPayload class]]){
@@ -222,8 +292,12 @@
                                                 }];
       next(newGroupContext);
     }
+    return;
+  }
 
-   return;
+  if (!cachedMarketingCloudId) {
+      next(context);
+    return;
   }
 }
 

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -70,6 +70,7 @@
     if (self.cachedMarketingCloudId.length == 0) {
         [self getMarketingCloudId:organizationId completion:^(NSString *marketingCloudId, NSError *error) {
           [defaults setObject:marketingCloudId forKey:@"com.segment.mcvid.marketingCloudId"];
+            self.cachedMarketingCloudId = [defaults stringForKey:@"com.segment.mcvid.marketingCloudId"];
             [self syncIntegrationCode:integrationCode userIdentifier:self.cachedAdvertisingId completion:^(NSError *error) {
               if (error) {
                   return;

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -253,17 +253,9 @@
       return;
     }
 
-  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-  NSString *cachedMarketingCloudId = [defaults stringForKey:@"MarketingCloudId"];
-
-  if (!cachedMarketingCloudId) {
+  if (!self.cachedMarketingCloudId) {
     next(context);
     return;
-  }
-
-  if (!_organizationId) {
-     next(context);
-     return;
   }
 
   SEGIdentifyPayload *identify =(SEGIdentifyPayload *)context.payload;
@@ -271,9 +263,9 @@
   SEGScreenPayload *screen =(SEGScreenPayload *)context.payload;
   SEGGroupPayload *group =(SEGGroupPayload *)context.payload;
 
-  if (cachedMarketingCloudId.length) {
+  if (self.cachedMarketingCloudId.length) {
     NSMutableDictionary *mergedIntegrations = [NSMutableDictionary dictionaryWithCapacity:100];
-    NSDictionary *mcidIntegrations = @{@"Adobe Analytics" : @{ @"marketingCloudVisitorId": cachedMarketingCloudId } };
+    NSDictionary *mcidIntegrations = @{@"Adobe Analytics" : @{ @"marketingCloudVisitorId": self.cachedMarketingCloudId } };
     [mergedIntegrations addEntriesFromDictionary:mcidIntegrations];
 
     if ([context.payload isKindOfClass:[SEGIdentifyPayload class]]){

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -14,7 +14,7 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
 @end
 
 @implementation MCVIDAdobeError
-- (id)initWithCode:(MCVIDAdobeErrorCode)code message:(NSString *)message error:(NSError *)error {
+- (id)initWithCode:(MCVIDAdobeErrorCode)code message:(NSString * _Nullable)message error:(NSError * _Nullable)error {
    self = [super  init];
    if (self) {
      _code = code;
@@ -29,17 +29,17 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
     @property(nonatomic) NSUInteger maxRetryCount;
     @property(nonatomic) NSUInteger currentRetryCount;
     @property(nonatomic) NSUInteger maxRetryTimeSecs;
-    @property(nonatomic) NSString *cachedMarketingCloudId;
-    @property(nonatomic) NSString *cachedAdvertisingId;
+    @property(nonatomic, nonnull) NSString *cachedMarketingCloudId;
+    @property(nonatomic, nonnull) NSString *cachedAdvertisingId;
 @end
 
 @implementation SEGMCVIDTracker
 
-+ (id<SEGMiddleware>)middlewareWithOrganizationId:(NSString *)organizationId region:(NSString *)region {
++ (id<SEGMiddleware>)middlewareWithOrganizationId:(NSString *_Nonnull)organizationId region:(NSString *_Nonnull)region {
     return [[SEGMCVIDTracker alloc] initWithOrganizationId: organizationId region:region ];
 }
 
--(id)initWithOrganizationId:(NSString *)organizationId region:(NSString *)region
+-(id)initWithOrganizationId:(NSString *_Nonnull)organizationId region:(NSString *_Nonnull)region
   {
     if (self = [super init])
     {
@@ -70,7 +70,7 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
     NSString *integrationCode = @"DSID_20915";
 
     if (self.cachedMarketingCloudId.length == 0) {
-        [self getMarketingCloudId:organizationId completion:^(NSString *marketingCloudId, NSError *error) {
+        [self getMarketingCloudId:organizationId completion:^(NSString  * _Nullable marketingCloudId, NSError * _Nullable error) {
           [defaults setObject:marketingCloudId forKey:@"com.segment.mcvid.marketingCloudId"];
             self.cachedMarketingCloudId = [defaults stringForKey:@"com.segment.mcvid.marketingCloudId"];
             [self syncIntegrationCode:integrationCode userIdentifier:self.cachedAdvertisingId completion:^(NSError *error) {
@@ -80,7 +80,7 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
           }];
         }];
     } else if (self.cachedMarketingCloudId.length != 0) {
-      [self syncIntegrationCode:integrationCode userIdentifier:self.cachedAdvertisingId completion:^(NSError *error) {
+      [self syncIntegrationCode:integrationCode userIdentifier:self.cachedAdvertisingId completion:^(NSError * _Nullable error) {
           if (error) {
               return;
           }
@@ -91,7 +91,7 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
     return self;
   }
 
-- (void)getMarketingCloudId:(NSString *)organizationId completion:(void (^)(NSString *marketingCloudId, NSError *))completion {
+- (void)getMarketingCloudId:(NSString *_Nonnull)organizationId completion:(void (^)(NSString * _Nullable marketingCloudId, NSError *_Nullable))completion {
 
     //Response and error handling variables
     NSString *errorResponseKey = @"errors";
@@ -143,14 +143,14 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
             dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * secondsToWait);
             dispatch_after(delay, self.backgroundQueue, ^(void){
                 self.currentRetryCount = self.currentRetryCount + 1;
-                [self getMarketingCloudId:organizationId completion:^(NSString *marketingCloudId, NSError *error) {
+                [self getMarketingCloudId:organizationId completion:^(NSString * _Nullable marketingCloudId, NSError * _Nullable error) {
                 }];
             });
         }
     }] resume];
 }
 
-- (void)syncIntegrationCode:(NSString *)integrationCode userIdentifier:(NSString *)userIdentifier completion:(void (^)(NSError *))completion {
+- (void)syncIntegrationCode:(NSString * _Nonnull)integrationCode userIdentifier:(NSString * _Nonnull)userIdentifier completion:(void (^)(NSError * _Nullable))completion {
 
     //Response and error handling variables
     NSString *errorResponseKey = @"errors";
@@ -190,21 +190,20 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
             return callbackWithCode(MCVIDAdobeErrorCodeServerError, errorMessage, errorObject);
         }
 
-
         if ((responseStatusCode == 200) && (!errorObject)){
             completion(nil);
         } else {
             dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * secondsToWait);
             dispatch_after(delay, self.backgroundQueue, ^(void){
                 self.currentRetryCount = self.currentRetryCount + 1;
-                [self syncIntegrationCode:integrationCode userIdentifier:self.cachedAdvertisingId completion:^(NSError *error){
+                [self syncIntegrationCode:integrationCode userIdentifier:self.cachedAdvertisingId completion:^(NSError * _Nullable error){
                 }];
             });
         }
     }] resume];
 }
 
-- (NSURL *)createURL:callType integrationCode:(NSString *)integrationCode {
+- (NSURL * _Nonnull)createURL:callType integrationCode:(NSString * _Nonnull)integrationCode {
     //Variables to build URL for GET request
     NSString *protocol = @"https";
     NSString *host = @"dpm.demdex.net";

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -136,6 +136,7 @@ NSString *const syncIntegrationCallType = @"syncIntegrationCode";
         }
 
         if (responseStatusCode == 200 && (!errorObject) ){
+            self.currentRetryCount = 0;
             completion(marketingCloudId, nil);
         } else {
             dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * secondsToWait);
@@ -187,6 +188,7 @@ NSString *const syncIntegrationCallType = @"syncIntegrationCode";
         }
 
         if ((responseStatusCode == 200) && (!errorObject)){
+            self.currentRetryCount = 0;
             completion(nil);
         } else {
             dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * secondsToWait);

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -55,15 +55,15 @@
 
     //Store advertisingId and marketingCloudId on local storage
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    _cachedMarketingCloudId = [defaults stringForKey:@"MarketingCloudId"];
-    
-      [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+    [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
     //This is was SEGIDFA() is going under the hood. NSString *idfaString = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
     NSString *segIdfa = SEGIDFA();
-    if (![self.cachedAdvertisingId isEqualToString:segIdfa]) {
+    _cachedMarketingCloudId = [defaults stringForKey:@"MarketingCloudId"];
+    if (![_cachedAdvertisingId isEqualToString:segIdfa]) {
         [defaults setObject:segIdfa forKey:@"AdvertisingId"];
+        _cachedAdvertisingId = [defaults stringForKey:@"AdvertisingId"];
     }
-    _cachedAdvertisingId = [defaults stringForKey:@"AdvertisingId"];
+    
     
     //Defaut value for integration code which indicate ios
     NSString *integrationCode = @"DSID_20915";

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -56,16 +56,17 @@
     //Store advertisingId and marketingCloudId on local storage
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     _cachedMarketingCloudId = [defaults stringForKey:@"MarketingCloudId"];
-    _cachedAdvertisingId = [defaults stringForKey:@"AdvertisingId"];
-    [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+    
+      [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
     //This is was SEGIDFA() is going under the hood. NSString *idfaString = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
     NSString *segIdfa = SEGIDFA();
-    NSString *integrationCode = @"DSID_20915";//means ios
-
-      
     if (![self.cachedAdvertisingId isEqualToString:segIdfa]) {
         [defaults setObject:segIdfa forKey:@"AdvertisingId"];
     }
+    _cachedAdvertisingId = [defaults stringForKey:@"AdvertisingId"];
+    
+    //Defaut value for integration code which indicate ios
+    NSString *integrationCode = @"DSID_20915";
 
     if (self.cachedMarketingCloudId.length == 0 || (segIdfa != self.cachedAdvertisingId)) {
         [self getMarketingCloudId:organizationId completion:^(NSString *marketingCloudId, NSError *error) {

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -264,54 +264,107 @@ NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
   SEGGroupPayload *group =(SEGGroupPayload *)context.payload;
 
   if (self.cachedMarketingCloudId.length) {
-    NSMutableDictionary *mergedIntegrations = [NSMutableDictionary dictionaryWithCapacity:100];
-    NSDictionary *mcidIntegrations = @{@"Adobe Analytics" : @{ @"marketingCloudVisitorId": self.cachedMarketingCloudId } };
-    [mergedIntegrations addEntriesFromDictionary:mcidIntegrations];
+    NSMutableDictionary *adobeOptions = [NSMutableDictionary new];
 
     if ([context.payload isKindOfClass:[SEGIdentifyPayload class]]){
-      [mergedIntegrations addEntriesFromDictionary:identify.integrations];
-      SEGContext *newIdentifyContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
-          ctx.payload = [[SEGIdentifyPayload alloc] initWithUserId:identify.userId
+        if ((identify.integrations != NULL) && ([identify.integrations objectForKey:@"Adobe Analytics"])){
+            NSDictionary *existingAAOptions = identify.integrations[@"Adobe Analytics"];
+            [adobeOptions addEntriesFromDictionary:existingAAOptions];
+            [adobeOptions setObject:self.cachedMarketingCloudId forKey:@"marketingCloudVisitorId"];
+        }
+        
+        NSMutableDictionary *integrations = [NSMutableDictionary new];
+        if (identify.integrations != NULL) {
+            NSMutableDictionary *existingIntegrations = [NSMutableDictionary new];
+            [existingIntegrations addEntriesFromDictionary:identify.integrations];
+            [existingIntegrations removeObjectForKey:@"Adobe Analytics"];
+            [integrations addEntriesFromDictionary:existingIntegrations];
+            [integrations setObject:adobeOptions forKey:@"Adobe Analytics"];
+        }
+        SEGContext *newIdentifyContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
+            ctx.payload = [[SEGIdentifyPayload alloc] initWithUserId:identify.userId
                                                     anonymousId:identify.anonymousId
                                                     traits: identify.traits
                                                     context:identify.context
-                                                    integrations: mergedIntegrations];
+                                                    integrations: integrations];
                                                   }];
 
-      next(newIdentifyContext);
+        next(newIdentifyContext);
     }
 
     if ([context.payload isKindOfClass:[SEGTrackPayload class]]){
-      [mergedIntegrations addEntriesFromDictionary:track.integrations];
-      SEGContext *newTrackContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
+        if ((track.integrations != NULL) && ([track.integrations objectForKey:@"Adobe Analytics"])){
+            NSDictionary *existingAAOptions = track.integrations[@"Adobe Analytics"];
+            [adobeOptions addEntriesFromDictionary:existingAAOptions];
+            [adobeOptions setObject:self.cachedMarketingCloudId forKey:@"marketingCloudVisitorId"];
+        }
+        
+        NSMutableDictionary *integrations = [NSMutableDictionary new];
+        if (track.integrations != NULL) {
+            NSMutableDictionary *existingIntegrations = [NSMutableDictionary new];
+            [existingIntegrations addEntriesFromDictionary:track.integrations];
+            [existingIntegrations removeObjectForKey:@"Adobe Analytics"];
+            [integrations addEntriesFromDictionary:existingIntegrations];
+            [integrations setObject:adobeOptions forKey:@"Adobe Analytics"];
+        }
+
+        SEGContext *newTrackContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
           ctx.payload = [[SEGTrackPayload alloc] initWithEvent:track.event
                                                     properties:track.properties
                                                     context:track.context
-                                                    integrations: mergedIntegrations];
+                                                    integrations: integrations];
                                                   }];
-      next(newTrackContext);
+        next(newTrackContext);
     }
 
     if ([context.payload isKindOfClass:[SEGScreenPayload class]]){
-      [mergedIntegrations addEntriesFromDictionary:screen.integrations];
-      SEGContext *newScreenContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
+        if ((screen.integrations != NULL) && ([screen.integrations objectForKey:@"Adobe Analytics"])){
+            NSDictionary *existingAAOptions = screen.integrations[@"Adobe Analytics"];
+            [adobeOptions addEntriesFromDictionary:existingAAOptions];
+            [adobeOptions setObject:self.cachedMarketingCloudId forKey:@"marketingCloudVisitorId"];
+        }
+        
+        NSMutableDictionary *integrations = [NSMutableDictionary new];
+        if (screen.integrations != NULL) {
+            NSMutableDictionary *existingIntegrations = [NSMutableDictionary new];
+            [existingIntegrations addEntriesFromDictionary:screen.integrations];
+            [existingIntegrations removeObjectForKey:@"Adobe Analytics"];
+            [integrations addEntriesFromDictionary:existingIntegrations];
+            [integrations setObject:adobeOptions forKey:@"Adobe Analytics"];
+        }
+        
+        SEGContext *newScreenContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
           ctx.payload = [[SEGScreenPayload alloc] initWithName:screen.name
                                                   properties:screen.properties
                                                   context:screen.context
-                                                  integrations: mergedIntegrations];
+                                                  integrations: integrations];
                                                 }];
-      next(newScreenContext);
+        next(newScreenContext);
     }
 
     if ([context.payload isKindOfClass:[SEGGroupPayload class]]){
-      [mergedIntegrations addEntriesFromDictionary:group.integrations];
-      SEGContext *newGroupContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
+        if ((group.integrations != NULL) && ([group.integrations objectForKey:@"Adobe Analytics"])){
+            NSDictionary *existingAAOptions = group.integrations[@"Adobe Analytics"];
+            [adobeOptions addEntriesFromDictionary:existingAAOptions];
+            [adobeOptions setObject:self.cachedMarketingCloudId forKey:@"marketingCloudVisitorId"];
+        }
+        
+        NSMutableDictionary *integrations = [NSMutableDictionary new];
+        if (group.integrations != NULL) {
+            NSMutableDictionary *existingIntegrations = [NSMutableDictionary new];
+            [existingIntegrations addEntriesFromDictionary:group.integrations];
+            [existingIntegrations removeObjectForKey:@"Adobe Analytics"];
+            [integrations addEntriesFromDictionary:existingIntegrations];
+            [integrations setObject:adobeOptions forKey:@"Adobe Analytics"];
+        }
+        
+        SEGContext *newGroupContext = [context modify:^(id<SEGMutableContext> _Nonnull ctx) {
           ctx.payload = [[SEGGroupPayload alloc] initWithGroupId:group.groupId
                                                   traits: group.traits
                                                   context:group.context
-                                                  integrations: mergedIntegrations];
+                                                  integrations: integrations];
                                                 }];
-      next(newGroupContext);
+        next(newGroupContext);
     }
     return;
   }

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -130,13 +130,8 @@
         
         //Logic for exponential backoff algorithm
         NSUInteger secondsToWait = pow(2, self.currentRetryCount);
-        NSUInteger secondsWaited = self.currentRetryCount * (self.currentRetryCount + 1)  * ((2 * self.currentRetryCount) + 1)/6;
 
         if ((self.currentRetryCount > self.maxRetryCount) && errorObject) {
-            return callbackWithCode(MCVIDAdobeErrorCodeServerError, errorMessage, errorObject);
-        }
-
-        if ((secondsWaited / 1 >= self.maxRetryTimeSecs) && errorObject) {
             return callbackWithCode(MCVIDAdobeErrorCodeServerError, errorMessage, errorObject);
         }
 
@@ -189,16 +184,11 @@
         NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
         NSInteger responseStatusCode = [httpResponse statusCode];
         NSUInteger secondsToWait = pow(2, self.currentRetryCount);
-        NSUInteger secondsWaited = self.currentRetryCount * (self.currentRetryCount + 1)  * ((2 * self.currentRetryCount) + 1)/6;
         
         if ((self.currentRetryCount > self.maxRetryCount) && (errorObject)) {
             return callbackWithCode(MCVIDAdobeErrorCodeServerError, errorMessage, errorObject);
-
         }
         
-        if (secondsWaited / 1 >= self.maxRetryTimeSecs && (errorObject)) {
-            return callbackWithCode(MCVIDAdobeErrorCodeServerError, errorMessage, errorObject);
-        }
         
         if ((responseStatusCode == 200) && (!errorObject)){
             completion(nil);

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -42,6 +42,8 @@
     NSUInteger maxRetryCount = 11;
     NSUInteger currentRetryCount = 1;
     NSUInteger maxRetryTimeSecs = 300;
+    self.backgroundQueue = dispatch_queue_create("com.segment.mcvid", NULL);
+
 
     //Store advertisingId and marketingCloudId on local storage
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
@@ -86,6 +88,7 @@
     NSString *advertisingId = nil;
 
     NSURL *url = [self createURL:advertisingId organizationId:organizationId marketingCloudId:marketingCloud];
+
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
     NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
@@ -108,7 +111,6 @@
 
         
         // or { ..., "errors": [{ "code": 2, "msg": "error" } ... ], ... }
-        NSDictionary *errorDictionary = dictionary[errorResponseKey];
         NSError *errorObject = dictionary[errorResponseKey][0];
         NSString *errorMessage = dictionary[@"errors"][0][@"msg"];
         
@@ -131,7 +133,6 @@
             completion(marketingCloudId, nil);
         } else {
             dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * milliSecondsToWait);
-            self.backgroundQueue = dispatch_queue_create("com.exmaple.MyCustomQueue", NULL);
             dispatch_after(delay, self.backgroundQueue, ^(void){
                 [self getMarketingCloudId:organizationId maxRetryCount:maxRetryCount currentRetryCount:currentRetryCount+1 maxRetryTimeSecs:maxRetryTimeSecs completion:^(NSString *marketingCloudId, NSError *error) {
                 }];
@@ -168,7 +169,6 @@
         }
         
         // or { ..., "errors": [{ "code": 2, "msg": "error" } ... ], ... }
-        NSDictionary *errorDictionary = dictionary[errorResponseKey];
         NSError *errorObject = dictionary[errorResponseKey][0];
         NSString *errorMessage = dictionary[@"errors"][0][@"msg"];
         
@@ -191,7 +191,6 @@
             completion(nil);
         } else {
             dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * milliSecondsToWait);
-            self.backgroundQueue = dispatch_queue_create("com.exmaple.MyCustomQueueu", NULL);
             dispatch_after(delay, self.backgroundQueue, ^(void){
                 [self syncMarketingCloudId:advertisingId organizationId:organizationId marketingCloudId:marketingCloudId maxRetryCount:maxRetryCount currentRetryCount:currentRetryCount+1 maxRetryTimeSecs:maxRetryTimeSecs completion:^(NSError *error){
                 }];
@@ -230,6 +229,7 @@
     [queryItems addObject:[NSURLQueryItem queryItemWithName:jsonFormatterKey value:jsonFormatter]];
     [queryItems addObject:[NSURLQueryItem queryItemWithName:regionKey value:region]];
     [queryItems addObject:[NSURLQueryItem queryItemWithName:organizationIdKey value:organizationId]];
+    
     if (marketingCloudId) {
         [queryItems addObject:[NSURLQueryItem queryItemWithName:marketingCloudIdKey value:marketingCloudId]];
         NSString *encodedAdvertisingValue = [NSString stringWithFormat:@"%@%@%@", deviceTypeKey, separator, advertisingId];

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -138,27 +138,27 @@
 
         NSString *marketingCloudId = dictionary[marketingCloudIdKey];
         NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
-        NSInteger responseStatusCode = [httpResponse statusCode];
+        __block NSInteger responseStatusCode = 400;
+//        [httpResponse statusCode];
 
         if ((responseStatusCode != 200) || ([marketingCloudId isEqualToString:invalidMarketingCloudId])){
            dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 10);
            dispatch_after(delay, dispatch_get_main_queue(), ^(void){
-               [self getMarketingCloudId:organizationId completion:^(NSString *marketingCloudId, NSError *error) {
-                   NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
-                   NSInteger newResponseStatusCode = [httpResponse statusCode];
-                   NSLog(@"This is the reponse statusCode within the dispatch %lu", newResponseStatusCode);
-                   if (newResponseStatusCode == 200) {
-//                       NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-//                       [defaults setObject:marketingCloudId forKey:@"MarketingCloudId"];
-//                       NSLog(@"this is  the new cached MCVID %@", marketingCloudId);
-//                       NSLog(@"this is  the new cached MCVID %@", ([defaults stringForKey:@"MarketingCloudId"]));
-                       completion(marketingCloudId, nil);
-                       return;
-                   }
-               }];
-           });
+               if (responseStatusCode != 200) {
+                   NSLog(@"This is the reponse statusCode before the dispatch %lu", responseStatusCode);
+                   [self getMarketingCloudId:organizationId completion:^(NSString *marketingCloudId, NSError *error) {
+                       NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
+                       responseStatusCode = [httpResponse statusCode];
+                       NSLog(@"This is the reponse statusCode within the dispatch %lu", responseStatusCode);
+                       if (responseStatusCode == 200) {
+                           completion(marketingCloudId, nil);
+                       }
+                   }];
+                }
+            });
+               
         }
-        completion(marketingCloudId, nil);
+          completion(marketingCloudId, nil);
     }] resume];
 }
 


### PR DESCRIPTION
**What does this PR do?**

- [x] Adds ID and Sync calls to the constructor of the middleware 
* Note it will `getMarketingCloudId` and then `syncAdvertisingId` if we don't have a `cachedMarketingCloudId`. Otherwise it will just `syncAdvertisingId` with the `cachedMarketingCloudId`. 
- [x]  Stores the `advertisingID` and `marketingCloudId` in iOS local storage (NSUserDefaults)
- [x] De-couples the API call into two API calls `getMarketingCloudId` and `syncAdvertsingId` 
- [x] Implements exponential backoff algorithm on API calls. The API calls will continue to retry if the call returns an error or if the responseStatusCode != 200. It will retry up to 10 times or until 5 minutes has hit. 
- [x] Improved error handling and incorporated into exponential backoff algorithm. An error will not be returned until the retry logic has exited. 
- [x] Is non-blocking. If there is no `cachedMarketingCloudId` events will continue to be sent to Segment without modification to payloads