### PR TITLE
[Bugfix] Critical issues

### DIFF
--- a/Example/Tests/SEGMiddlewareSpy.h
+++ b/Example/Tests/SEGMiddlewareSpy.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+#import <Analytics/SEGMiddleware.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SEGMiddlewareSpy : NSObject <SEGMiddleware>
+
+@property (nonatomic, assign, readonly) SEGEventType lastEventType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/Tests/SEGMiddlewareSpy.m
+++ b/Example/Tests/SEGMiddlewareSpy.m
@@ -1,0 +1,24 @@
+//
+//  SEGMiddlewareSpy.m
+//  analytics-ios-mcvid_Tests
+//
+//  Created by Xavier Jurado on 01/08/2019.
+//  Copyright © 2019 Brie. All rights reserved.
+//
+
+#import "SEGMiddlewareSpy.h"
+
+@interface SEGMiddlewareSpy ()
+
+@property (nonatomic, assign) SEGEventType lastEventType;
+
+@end
+
+@implementation SEGMiddlewareSpy
+
+- (void)context:(SEGContext * _Nonnull)context next:(SEGMiddlewareNext _Nonnull)next {
+    self.lastEventType = context.eventType;
+    next(context);
+}
+
+@end

--- a/Example/Tests/SEGMiddlewareSpy.m
+++ b/Example/Tests/SEGMiddlewareSpy.m
@@ -1,11 +1,3 @@
-//
-//  SEGMiddlewareSpy.m
-//  analytics-ios-mcvid_Tests
-//
-//  Created by Xavier Jurado on 01/08/2019.
-//  Copyright © 2019 Brie. All rights reserved.
-//
-
 #import "SEGMiddlewareSpy.h"
 
 @interface SEGMiddlewareSpy ()

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -99,6 +99,18 @@ describe(@"SEGMCVID", ^{
 
         expect(spy.lastEventType).will.equal(SEGEventTypeFlush);
     });
+
+    it(@"Does not attempt to perform an idsync if no mcvid is available yet", ^{
+        SEGMCVIDTracker *mcvid = [[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region];
+
+        __block NSError *mcvidError = nil;
+        [mcvid setValue:nil forKey:@"cachedMarketingCloudId"];
+        [mcvid syncIntegrationCode:@"integration_code" userIdentifier:@"user_id" completion:^(NSError *error) {
+            mcvidError = error;
+        }];
+
+        expect(mcvidError.code).will.equal(MCVIDAdobeErrorCodeUnavailable);
+    });
 });
 
 describe(@"createURL function", ^{

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -13,6 +13,7 @@
 #import <Analytics/SEGAnalytics.h>
 #import "SEGAppDelegate.h"
 #import "SEGPayload.h"
+#import "SEGMiddlewareSpy.h"
 
 // https://github.com/Specta/Specta
 @interface SEGMCVIDTracker (Testing)
@@ -77,7 +78,21 @@ describe(@"SEGMCVID", ^{
                                    properties:nil
                                       options:@{ @"integrations": @{ @"All": @YES, @"Mixpanel": @NO, @"Adobe Analytics":@{ @"prop1":@"Hello World"} }}];
     });
-    
+
+    it(@"ignores non track events", ^{
+        SEGMCVIDTracker *mcvid = [[SEGMCVIDTracker alloc] initWithOrganizationId:organizationId region:region];
+        SEGMiddlewareSpy *spy = [[SEGMiddlewareSpy alloc] init];
+
+        SEGAnalyticsConfiguration *configuration =  [SEGAnalyticsConfiguration configurationWithWriteKey:@"some_write_key"];
+        configuration.middlewares = @[mcvid, spy];
+
+        SEGAnalytics *analytics = [[SEGAnalytics alloc] initWithConfiguration:configuration];
+
+        [mcvid setValue:@"fake" forKey:@"cachedMarketingCloudId"];
+        [analytics flush];
+
+        expect(spy.lastEventType).will.equal(SEGEventTypeFlush);
+    });
 });
 
 describe(@"createURL function", ^{

--- a/Example/analytics-ios-mcvid.xcodeproj/project.pbxproj
+++ b/Example/analytics-ios-mcvid.xcodeproj/project.pbxproj
@@ -253,7 +253,7 @@
 			attributes = {
 				CLASSPREFIX = SEG;
 				LastUpgradeCheck = 0720;
-				ORGANIZATIONNAME = Brie;
+				ORGANIZATIONNAME = Segment;
 				TargetAttributes = {
 					6003F5AD195388D20070C39A = {
 						TestTargetID = 6003F589195388D20070C39A;

--- a/Example/analytics-ios-mcvid.xcodeproj/project.pbxproj
+++ b/Example/analytics-ios-mcvid.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		47FCDA3522F355AB0039DDD9 /* SEGMiddlewareSpy.m in Sources */ = {isa = PBXBuildFile; fileRef = 47FCDA3422F355AB0039DDD9 /* SEGMiddlewareSpy.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -39,6 +40,8 @@
 
 /* Begin PBXFileReference section */
 		067A5F01093BE1FE1292EAD0 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		47FCDA3322F355AB0039DDD9 /* SEGMiddlewareSpy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SEGMiddlewareSpy.h; sourceTree = "<group>"; };
+		47FCDA3422F355AB0039DDD9 /* SEGMiddlewareSpy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SEGMiddlewareSpy.m; sourceTree = "<group>"; };
 		4E51670D92D3474438551ECF /* Pods-analytics-ios-mcvid_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-analytics-ios-mcvid_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-analytics-ios-mcvid_Tests/Pods-analytics-ios-mcvid_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* analytics-ios-mcvid_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "analytics-ios-mcvid_Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -174,6 +177,8 @@
 		6003F5B5195388D20070C39A /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				47FCDA3322F355AB0039DDD9 /* SEGMiddlewareSpy.h */,
+				47FCDA3422F355AB0039DDD9 /* SEGMiddlewareSpy.m */,
 				6003F5BB195388D20070C39A /* Tests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
@@ -359,6 +364,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				47FCDA3522F355AB0039DDD9 /* SEGMiddlewareSpy.m in Sources */,
 				6003F5BC195388D20070C39A /* Tests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -3,7 +3,8 @@
 
 @interface SEGMCVIDTracker : NSObject <SEGMiddleware>
 
--(id _Nonnull)initWithOrganizationId:(NSString *_Nonnull)organizationId region:(NSString *_Nonnull)region;
+- (instancetype _Nonnull)init NS_UNAVAILABLE;
+- (instancetype _Nonnull)initWithOrganizationId:(NSString *_Nonnull)organizationId region:(NSString *_Nonnull)region NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, strong, nonnull) NSString *organizationId;
 @property (nonatomic, strong, nonnull) NSString *region;

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.h
@@ -20,7 +20,9 @@ typedef NS_ENUM(NSInteger, MCVIDAdobeErrorCode) {
     // Unable to deserialize JSON from response
     MCVIDAdobeErrorCodeClientSerializationError,
     // An error was provided by the server
-    MCVIDAdobeErrorCodeServerError
+    MCVIDAdobeErrorCodeServerError,
+    // The MCVID is not yet available
+    MCVIDAdobeErrorCodeUnavailable
 };
 
 @interface MCVIDAdobeError : NSObject

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -145,10 +145,18 @@ NSString *const cachedAdvertisingIdKey = @"com.segment.mcvid.advertisingId";
 }
 
 - (void)syncIntegrationCode:(NSString * _Nonnull)integrationCode userIdentifier:(NSString * _Nonnull)userIdentifier completion:(void (^)(NSError * _Nullable))completion {
-
     //Response and error handling variables
     NSString *errorResponseKey = @"errors";
     NSString *errorDomain = @"Segment-Adobe";
+
+    // We cannot perform an idsync if we don't have a MCVID.
+    if (self.cachedMarketingCloudId.length == 0) {
+        NSString *message = @"A MCVID is not yet available. Please, retry the operation later.";
+        MCVIDAdobeError *adobeError = [[MCVIDAdobeError alloc] initWithCode:MCVIDAdobeErrorCodeUnavailable message:message error:nil];
+        NSError *compositeError = [NSError errorWithDomain:errorDomain code:adobeError.code userInfo:@{MCVIDAdobeErrorKey:adobeError}];
+        completion(compositeError);
+        return;
+    }
 
     NSArray<NSURLQueryItem *>* syncQueryItems = [self URLQueryItemsForIntegrationCode:integrationCode userIdentifier:userIdentifier];
     NSURL *url = [self createURLWithAdditionalQueryItems:syncQueryItems];

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -39,10 +39,6 @@ NSString *const cachedAdvertisingIdKey = @"com.segment.mcvid.advertisingId";
 
 @implementation SEGMCVIDTracker
 
-+ (id<SEGMiddleware>)middlewareWithOrganizationId:(NSString *_Nonnull)organizationId region:(NSString *_Nonnull)region {
-    return [[SEGMCVIDTracker alloc] initWithOrganizationId: organizationId region:region ];
-}
-
 -(id)initWithOrganizationId:(NSString *_Nonnull)organizationId region:(NSString *_Nonnull)region
   {
     if (self = [super init])

--- a/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
+++ b/analytics-ios-mcvid/Classes/SEGMCVIDTracker.m
@@ -6,8 +6,6 @@
 #include <math.h>
 
 NSString *const MCVIDAdobeErrorKey = @"MCVIDAdobeErrorKey";
-NSString *const getCloudIdCallType = @"getMarketingCloudID";
-NSString *const syncIntegrationCallType = @"syncIntegrationCode";
 NSString *const cachedMarketingCloudIdKey = @"com.segment.mcvid.marketingCloudId";
 NSString *const cachedAdvertisingIdKey = @"com.segment.mcvid.advertisingId";
 
@@ -100,7 +98,7 @@ NSString *const cachedAdvertisingIdKey = @"com.segment.mcvid.advertisingId";
     NSString *errorDomain = @"Segment-Adobe";
     NSString *marketingCloudIdKey = @"d_mid";
 
-    NSURL *url = [self createURL:getCloudIdCallType integrationCode:@"DSID_20915"];
+    NSURL *url = [self createURLWithAdditionalQueryItems:nil];
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
@@ -156,7 +154,8 @@ NSString *const cachedAdvertisingIdKey = @"com.segment.mcvid.advertisingId";
     NSString *errorResponseKey = @"errors";
     NSString *errorDomain = @"Segment-Adobe";
 
-    NSURL *url = [self createURL:syncIntegrationCallType integrationCode:integrationCode];
+    NSArray<NSURLQueryItem *>* syncQueryItems = [self URLQueryItemsForIntegrationCode:integrationCode userIdentifier:userIdentifier];
+    NSURL *url = [self createURLWithAdditionalQueryItems:syncQueryItems];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
     NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
@@ -202,11 +201,7 @@ NSString *const cachedAdvertisingIdKey = @"com.segment.mcvid.advertisingId";
     }] resume];
 }
 
-- (NSURL * _Nonnull)createURL:(NSString *_Nonnull)callType integrationCode:(NSString * _Nonnull)integrationCode {
-    return [self createURL:callType integrationCode:integrationCode userIdentifier:self.cachedAdvertisingId];
-}
-
-- (NSURL * _Nonnull)createURL:(NSString *_Nonnull)callType integrationCode:(NSString * _Nonnull)integrationCode userIdentifier:(NSString* _Nullable)userIdentifier {
+- (NSURL * _Nonnull)createURLWithAdditionalQueryItems:(NSArray<NSURLQueryItem *>* _Nullable)extraQueryItems {
     //Variables to build URL for GET request
     NSString *protocol = @"https";
     NSString *host = @"dpm.demdex.net";
@@ -219,12 +214,7 @@ NSString *const cachedAdvertisingIdKey = @"com.segment.mcvid.advertisingId";
     NSString *jsonFormatter = @"json";//&d_rtbd and defaults to = json
     NSString *regionKey = @"dcs_region"; //dcs_region key defaults to = 6
     NSString *region = _region; //dcs_region
-    NSString *marketingCloudIdKey = @"d_mid";
     NSString *organizationIdKey = @"d_orgid"; //can retrieve from settings
-
-    //Variables for when advertising Id is present
-    NSString *separator = @"%01";
-    NSString *advertisingIdKey = @"d_cid_ic";
 
     //Values to build URl components and query items
     NSMutableString *urlString = [NSMutableString stringWithFormat:@"%@://%@%@", protocol, host, path];
@@ -236,17 +226,32 @@ NSString *const cachedAdvertisingIdKey = @"com.segment.mcvid.advertisingId";
     [queryItems addObject:[NSURLQueryItem queryItemWithName:regionKey value:region]];
     [queryItems addObject:[NSURLQueryItem queryItemWithName:organizationIdKey value:self.organizationId]];
 
-    if ([callType isEqualToString:@"syncIntegrationCode"]) {
-        [queryItems addObject:[NSURLQueryItem queryItemWithName:marketingCloudIdKey value:self.cachedMarketingCloudId]];
-        NSString *encodedAdvertisingValue = [NSString stringWithFormat:@"%@%@%@", integrationCode, separator, userIdentifier];
-        //removes %25 html encoding of '%'
-        NSString *normalAdvertisingValue = [encodedAdvertisingValue stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-        [queryItems addObject:[NSURLQueryItem queryItemWithName:advertisingIdKey value:normalAdvertisingValue]];
+    if (extraQueryItems.count > 0) {
+        [queryItems addObjectsFromArray:extraQueryItems];
     }
     components.queryItems = queryItems;
     NSURL *url = components.URL;
 
     return url;
+}
+
+- (NSArray<NSURLQueryItem *>* _Nonnull)URLQueryItemsForIntegrationCode:(NSString * _Nonnull)integrationCode userIdentifier:(NSString* _Nonnull)userIdentifier {
+    NSString *marketingCloudIdKey = @"d_mid";
+    NSString *advertisingIdKey = @"d_cid_ic";
+    NSString *separator = @"%01";
+
+    NSMutableArray *queryItems = [NSMutableArray array];
+
+    // d_mid=<marketing_cloud_visitor_id>
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:marketingCloudIdKey value:self.cachedMarketingCloudId]];
+
+    // d_cid_ic=<integration_code>%01<user_identifier>
+    NSString *encodedAdvertisingValue = [NSString stringWithFormat:@"%@%@%@", integrationCode, separator, userIdentifier];
+    //removes %25 html encoding of '%'
+    NSString *normalAdvertisingValue = [encodedAdvertisingValue stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:advertisingIdKey value:normalAdvertisingValue]];
+
+    return queryItems;
 }
 
 - (NSMutableDictionary * _Nonnull)buildIntegrationsObject:(SEGPayload *_Nonnull)payload {


### PR DESCRIPTION
# Description

We have found two critical issues in the current implementation.

## Passthrough events

As per `SEGMiddleware` contract:

> Middleware should **always** call `next`.

Sadly this is not the case with the current implementation. Events of types different that `group`, `payload`, `track`, `identify` and `screen` won't be forwarded to the next middleware. This is a **critical bug** that makes some core functionality like automatic event flushing or identify reset stop working altogether.

## ID-sync 

The method:

```objc
- (void)syncIntegrationCode:(NSString *_Nonnull)integrationCode userIdentifier:(NSString *_Nonnull)userIdentifier completion:(void (^_Nonnull)(NSError *_Nullable))completion;
```

Was ignoring whatever was sent as `userIdentifier` and used the advertising identifier instead, rendering the whole method useless outside of the framework.
