### PR TITLE
Depend on Analytics 3.6 or greater

### DIFF
--- a/analytics-ios-mcvid.podspec
+++ b/analytics-ios-mcvid.podspec
@@ -31,5 +31,5 @@ Analytics-ios-mcvid requests the marketingCloudId from Adobe and appends it to i
 
   s.source_files = 'analytics-ios-mcvid/Classes/**/*'
 
-  s.dependency 'Analytics', '~> 3.6.0'
+  s.dependency 'Analytics', '~> 3.6'
 end


### PR DESCRIPTION
The current podspec fixes both major and minor versions of the main Segment library, thus blocking us from updating to 3.7 or newer versions. This PR solves that.