### PR TITLE
Set AdvertisingIdProvider after init

### DIFF
--- a/AnalyticsMVCID/Classes/SEGMCVIDTracker.h
+++ b/AnalyticsMVCID/Classes/SEGMCVIDTracker.h
@@ -38,6 +38,7 @@ typedef NS_ENUM(NSInteger, MCVIDGenerationMode) {
 @property (nonatomic, strong, nonnull) NSString *organizationId;
 @property (nonatomic, strong, nonnull) NSString *region;
 
+- (void)setAdvertisingIdProvider:(SEGAdSupportBlock _Nullable)advertisingIdProvider;
 - (void)syncIntegrationCode:(NSString *_Nonnull)integrationCode userIdentifier:(NSString *_Nonnull)userIdentifier completion:(void (^_Nonnull)(NSError *_Nullable))completion;
 - (void)syncIntegrationCode:(NSString *_Nonnull)integrationCode userIdentifier:(NSString *_Nonnull)userIdentifier authentication:(MCVIDAuthState)state completion:(void (^_Nonnull)(NSError *_Nullable))completion;
 

--- a/Example/analytics-ios-mcvid/SEGAppDelegate.m
+++ b/Example/analytics-ios-mcvid/SEGAppDelegate.m
@@ -19,12 +19,14 @@
     SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:@"YOUR_WRITE_KEY"];
 
     // Configure the client with the MCVID middleware. Intiliaze with your Adobe OrgId and Adobe Region (ie. dcs_region key)
-    configuration.sourceMiddleware = @[ [[SEGMCVIDTracker alloc]  initWithOrganizationId:@"YOUR_ORD_ID@AdobeOrg" region:@"YOUR_REGION_KEY" advertisingIdProvider:^NSString * _Nonnull {
-        return @"12345678901234567890123456789012345678";
-    }] ];
+    SEGMCVIDTracker *tracker = [[SEGMCVIDTracker alloc]  initWithOrganizationId:@"YOUR_ORD_ID@AdobeOrg" region:@"YOUR_REGION_KEY" advertisingIdProvider:nil mcvidGenerationMode:MCVIDGenerationModeLocal];
+    configuration.sourceMiddleware = @[tracker];
     configuration.trackApplicationLifecycleEvents = YES; // Enable this to record certain application events automatically!
     configuration.recordScreenViews = YES; // Enable this to record screen views automatically!
     configuration.flushAt = 1; // Flush events to Segment every 1 event
+    [tracker setAdvertisingIdProvider:^NSString * _Nonnull{
+        return @"12345678901234567890123456789012345678";
+    }];
     [SEGAnalytics setupWithConfiguration:configuration];
     [SEGAnalytics debug:YES];
     // Override point for customization after application launch.


### PR DESCRIPTION
`advertisingIdProvider` should be optional at the tracker's initialization as we don't know if the user has been asked yet to accept permission for being tracked (as per the new privacy settings after iOS 14).
We've added a new public method to set the identifier provider if it's not sent in the initialization of `SEGMCVIDTracker` and to call `syncAdvertisingIdentifier` if necessary.